### PR TITLE
HSL Receive interface and implementation using reprs

### DIFF
--- a/src/tls/HSL.Receive.fst
+++ b/src/tls/HSL.Receive.fst
@@ -15,6 +15,8 @@ module LP = LowParse.Low.Base
 
 module E = FStar.Error
 
+module Repr = MITLS.Repr
+
 open HSL.Common
 
 #reset-options "--max_fuel 0 --max_ifuel 0 --using_facts_from '* -FStar.Tactics -FStar.Reflection'"
@@ -63,7 +65,7 @@ let parse_hsm13
       cl.LP.clens_cond m ==> f (cl.LP.clens_get m) == m})
   (acc:LP.accessor gacc)
   : b:slice -> from:uint_32 ->
-    Stack (TLSError.result (option (G.erased a & uint_32)))
+    Stack (TLSError.result (option (Repr.repr_p a b p & uint_32)))
     (requires fun h ->
       B.live h b.LP.base /\
       from <= b.LP.len)
@@ -72,9 +74,9 @@ let parse_hsm13
       (match r with
        | E.Error _ -> True
        | E.Correct None -> True
-       | E.Correct (Some (a_msg, pos)) ->
-         pos <= b.LP.len /\
-         valid_parsing13 (f (G.reveal a_msg)) b from pos h1))
+       | E.Correct (Some (repr, pos)) ->
+         repr.Repr.start_pos == from /\
+         repr.Repr.end_pos == pos))
   = fun b from ->
     
     let pos = HSM.handshake13_validator b from in

--- a/src/tls/HSL.Receive.fst
+++ b/src/tls/HSL.Receive.fst
@@ -1,3 +1,20 @@
+(*
+  Copyright 2015--2019 INRIA and Microsoft Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Authors: T. Ramananandro, A. Rastogi, N. Swamy
+*)
 module HSL.Receive
 
 open FStar.Integers
@@ -10,12 +27,14 @@ module HS = FStar.HyperStack
 module ST = FStar.HyperStack.ST
 module B = LowStar.Buffer
 
-module HSM = HandshakeMessages
 module LP = LowParse.Low.Base
 
 module E = FStar.Error
 
-module Repr = MITLS.Repr
+module HSM13 = Parsers.Handshake13
+module HSMType = Parsers.HandshakeType
+module R = MITLS.Repr
+module HSM13R = MITLS.Repr.HSM13
 
 open HSL.Common
 
@@ -54,18 +73,15 @@ assume val bytes_remain_error : TLSError.error
 inline_for_extraction
 noextract
 let parse_hsm13
-  (#a:Type) (#k:LP.parser_kind{k.LP.parser_kind_subkind == Some LP.ParserStrong})
-  (#p:LP.parser k a) (#cl:LP.clens HSM.handshake13 a)
-  (#gacc:LP.gaccessor HSM.handshake13_parser p cl)
-  (tag:HSM.handshakeType{
-    forall (m:HSM.handshake13).
-      (HSM.tag_of_handshake13 m == tag) <==> cl.LP.clens_cond m})
-  (f:a -> HSM.handshake13{
-    forall (m:HSM.handshake13).
-      cl.LP.clens_cond m ==> f (cl.LP.clens_get m) == m})
+  (#a:Type) (#k:R.strong_parser_kind)
+  (#p:LP.parser k a) (#cl:LP.clens HSM13.handshake13 a)
+  (#gacc:LP.gaccessor HSM13.handshake13_parser p cl)
+  (tag:HSMType.handshakeType{
+    forall (m:HSM13.handshake13).
+      (HSM13.tag_of_handshake13 m == tag) <==> cl.LP.clens_cond m})
   (acc:LP.accessor gacc)
   : b:slice -> from:uint_32 ->
-    Stack (TLSError.result (option (Repr.repr_p a b p & uint_32)))
+    Stack (TLSError.result (option (HSM13R.repr b & uint_32)))
     (requires fun h ->
       B.live h b.LP.base /\
       from <= b.LP.len)
@@ -75,46 +91,24 @@ let parse_hsm13
        | E.Error _ -> True
        | E.Correct None -> True
        | E.Correct (Some (repr, pos)) ->
-         repr.Repr.start_pos == from /\
-         repr.Repr.end_pos == pos))
+         repr.R.start_pos == from /\
+         repr.R.end_pos == pos /\
+         R.valid repr h1 /\
+         cl.LP.clens_cond (R.value repr)))
+         
   = fun b from ->
     
-    let pos = HSM.handshake13_validator b from in
+    let pos = HSM13.handshake13_validator b from in
 
     if pos <= LP.validator_max_length then begin
-      let parsed_tag = HSM.handshakeType_reader b from in
+      let parsed_tag = HSMType.handshakeType_reader b from in
       if parsed_tag = tag then
-        let payload_begin = acc b from in
-        let payload =
-          let h = ST.get () in
-          let payload = LP.contents p h b payload_begin in
-          G.hide payload
-        in
-        E.Correct (Some (payload, pos))
+        let r = R.mk b from pos HSM13.handshake13_parser in
+        E.Correct (Some (r, pos))
       else E.Error unexpected_flight_error
     end
     else if pos = LP.validator_error_not_enough_data then E.Correct None
     else E.Error parsing_error
-
-let save_incremental_state
-  (st:hsl_state) (b:slice) (from to:uint_32) (in_progress:in_progress_flt_t)
-  : Stack unit
-    (requires fun h ->
-      B.live h st.inc_st /\
-      B.live h b.LP.base /\
-      B.loc_disjoint (footprint st) (B.loc_buffer b.LP.base) /\
-      from <= to /\ to <= b.LP.len)
-    (ensures fun h0 _ h1 ->
-      B.modifies (footprint st) h0 h1 /\
-      parsed_bytes st h1 ==
-        Seq.slice (B.as_seq h1 b.LP.base) (v from) (v to) /\
-      in_progress_flt st h1 == in_progress)
-  = let inc_st =
-      let h = ST.get () in
-      let parsed_bytes = LP.bytes_of_slice_from_to h b from to in
-      G.hide (parsed_bytes, in_progress)
-    in
-    B.upd st.inc_st 0ul inc_st
 
 let reset_incremental_state (st:hsl_state)
   : Stack unit
@@ -149,226 +143,206 @@ let err_or_insufficient_data
   = match parse_result with
     | E.Error e -> E.Error e
     | E.Correct None ->
-      save_incremental_state st b from to in_progress;
+      let inc_st =
+        let h = ST.get () in
+        let parsed_bytes = LP.bytes_of_slice_from_to h b from to in
+        G.hide (parsed_bytes, in_progress)
+      in
+      B.upd st.inc_st 0ul inc_st;
       E.Correct None
-
-unfold let parse_pre (b:slice) (from:uint_32)
-  : HS.mem -> Type0
-  = fun (h:HS.mem) -> B.live h b.LP.base /\ from <= b.LP.len
 
 let parse_hsm13_ee
   =  parse_hsm13
-      HSM.Encrypted_extensions HSM.M13_encrypted_extensions
+      HSM.Encrypted_extensions
       HSM.handshake13_accessor_encrypted_extensions
       
 let parse_hsm13_c
   = parse_hsm13
-      HSM.Certificate HSM.M13_certificate
+      HSM.Certificate
       HSM.handshake13_accessor_certificate
 
 let parse_hsm13_cv
   = parse_hsm13
-      HSM.Certificate_verify HSM.M13_certificate_verify
+      HSM.Certificate_verify
       HSM.handshake13_accessor_certificate_verify
 
 let parse_hsm13_fin
   = parse_hsm13 
-      HSM.Finished HSM.M13_finished
+      HSM.Finished
       HSM.handshake13_accessor_finished
 
 let parse_hsm13_cr
   = parse_hsm13 
-      HSM.Certificate_request HSM.M13_certificate_request
+      HSM.Certificate_request
       HSM.handshake13_accessor_certificate_request
 
 let parse_hsm13_eoed
   = parse_hsm13 
-      HSM.End_of_early_data HSM.M13_end_of_early_data
+      HSM.End_of_early_data
       HSM.handshake13_accessor_end_of_early_data
 
 let parse_hsm13_nst
   = parse_hsm13 
-      HSM.New_session_ticket HSM.M13_new_session_ticket
+      HSM.New_session_ticket
       HSM.handshake13_accessor_new_session_ticket
-
-let frame_valid_parsing13
-  (msg:HSM.handshake13)
-  (b:slice)
-  (from to:uint_32)
-  (l:B.loc)
-  (h0 h1:HS.mem)
-  : Lemma
-    (requires
-      valid_parsing13 msg b from to h0 /\
-      B.loc_disjoint l (B.loc_buffer b.LP.base) /\
-      B.modifies l h0 h1)
-    (ensures valid_parsing13 msg b from to h1)
-    [SMTPat (valid_parsing13 msg b from to h1);
-     SMTPat (B.modifies l h0 h1)]
-  = ()
-
-#reset-options "--max_fuel 0 --max_ifuel 0 --using_facts_from '* -FStar.Tactics -FStar.Reflection -LowParse +LowParse.Bytes +LowParse.Slice'"
 
 let receive_flight13_ee_c_cv_fin st b from to =
   let r = parse_hsm13_ee b from in
   match r with
   | E.Error _ | E.Correct None ->
     err_or_insufficient_data r F13_ee_c_cv_fin st b from to
-  | E.Correct (Some (ee_payload, c_begin)) ->
+  | E.Correct (Some (ee_repr, c_begin)) ->
     let r = parse_hsm13_c b c_begin in
     match r with
     | E.Error _ | E.Correct None ->
       err_or_insufficient_data r F13_ee_c_cv_fin st b from to
-    | E.Correct (Some (c_payload, cv_begin)) ->
+    | E.Correct (Some (c_repr, cv_begin)) ->
       let r = parse_hsm13_cv b cv_begin in
       match r with
       | E.Error _ | E.Correct None ->
         err_or_insufficient_data r F13_ee_c_cv_fin st b from to
-      | E.Correct (Some (cv_payload, fin_begin)) ->
+      | E.Correct (Some (cv_repr, fin_begin)) ->
         let r = parse_hsm13_fin b fin_begin in
         match r with
         | E.Error _ | E.Correct None ->
           err_or_insufficient_data r F13_ee_c_cv_fin st b from to
-        | E.Correct (Some (fin_payload, pos)) ->
+        | E.Correct (Some (fin_repr, pos)) ->
           if pos <> to then E.Error bytes_remain_error
           else begin
             reset_incremental_state st;
             E.Correct (Some ({
-              begin_c = c_begin;
-              begin_cv = cv_begin;
-              begin_fin = fin_begin;
-              ee_msg = ee_payload;
-              c_msg = c_payload;
-              cv_msg = cv_payload;
-              fin_msg = fin_payload
+              ee_msg = ee_repr;
+              c_msg = c_repr;
+              cv_msg = cv_repr;
+              fin_msg = fin_repr
             }))
           end
 
-let receive_flight13_ee_cr_c_cv_fin st b from to =
-  let r = parse_hsm13_ee b from in
-  match r with
-  | E.Error _ | E.Correct None ->
-    err_or_insufficient_data r F13_ee_cr_c_cv_fin st b from to
-  | E.Correct (Some (ee_payload, cr_begin)) ->
-    let r = parse_hsm13_cr b cr_begin in
-    match r with
-    | E.Error _ | E.Correct None ->
-      err_or_insufficient_data r F13_ee_cr_c_cv_fin st b from to
-    | E.Correct (Some (cr_payload, c_begin)) ->
-      let r = parse_hsm13_c b c_begin in
-      match r with
-      | E.Error _ | E.Correct None ->
-        err_or_insufficient_data r F13_ee_cr_c_cv_fin st b from to
-      | E.Correct (Some (c_payload, cv_begin)) ->
-        let r = parse_hsm13_cv b cv_begin in
-        match r with
-        | E.Error _ | E.Correct None ->
-          err_or_insufficient_data r F13_ee_cr_c_cv_fin st b from to
-        | E.Correct (Some (cv_payload, fin_begin)) ->
-          let r = parse_hsm13_fin b fin_begin in
-          match r with
-          | E.Error _ | E.Correct None ->
-            err_or_insufficient_data r F13_ee_cr_c_cv_fin st b from to
-          | E.Correct (Some (fin_payload, pos)) ->
-            if pos <> to then E.Error bytes_remain_error
-            else begin
-              reset_incremental_state st;
-              E.Correct (Some ({
-                begin_cr = cr_begin;
-                begin_c = c_begin;
-                begin_cv = cv_begin;
-                begin_fin = fin_begin;
-                ee_msg = ee_payload;
-                cr_msg = cr_payload;
-                c_msg = c_payload;
-                cv_msg = cv_payload;
-                fin_msg = fin_payload
-              }))
-            end
+// let receive_flight13_ee_cr_c_cv_fin st b from to =
+//   let r = parse_hsm13_ee b from in
+//   match r with
+//   | E.Error _ | E.Correct None ->
+//     err_or_insufficient_data r F13_ee_cr_c_cv_fin st b from to
+//   | E.Correct (Some (ee_payload, cr_begin)) ->
+//     let r = parse_hsm13_cr b cr_begin in
+//     match r with
+//     | E.Error _ | E.Correct None ->
+//       err_or_insufficient_data r F13_ee_cr_c_cv_fin st b from to
+//     | E.Correct (Some (cr_payload, c_begin)) ->
+//       let r = parse_hsm13_c b c_begin in
+//       match r with
+//       | E.Error _ | E.Correct None ->
+//         err_or_insufficient_data r F13_ee_cr_c_cv_fin st b from to
+//       | E.Correct (Some (c_payload, cv_begin)) ->
+//         let r = parse_hsm13_cv b cv_begin in
+//         match r with
+//         | E.Error _ | E.Correct None ->
+//           err_or_insufficient_data r F13_ee_cr_c_cv_fin st b from to
+//         | E.Correct (Some (cv_payload, fin_begin)) ->
+//           let r = parse_hsm13_fin b fin_begin in
+//           match r with
+//           | E.Error _ | E.Correct None ->
+//             err_or_insufficient_data r F13_ee_cr_c_cv_fin st b from to
+//           | E.Correct (Some (fin_payload, pos)) ->
+//             if pos <> to then E.Error bytes_remain_error
+//             else begin
+//               reset_incremental_state st;
+//               E.Correct (Some ({
+//                 begin_cr = cr_begin;
+//                 begin_c = c_begin;
+//                 begin_cv = cv_begin;
+//                 begin_fin = fin_begin;
+//                 ee_msg = ee_payload;
+//                 cr_msg = cr_payload;
+//                 c_msg = c_payload;
+//                 cv_msg = cv_payload;
+//                 fin_msg = fin_payload
+//               }))
+//             end
 
-let mk_ee_fin
-  (begin_fin:uint_32)
-  (ee_msg:G.erased HSM.handshake13_m13_encrypted_extensions) 
-  (fin_msg:G.erased HSM.handshake13_m13_finished)
-  : flight13_ee_fin
-  = Mkflight13_ee_fin begin_fin ee_msg fin_msg
+// let mk_ee_fin
+//   (begin_fin:uint_32)
+//   (ee_msg:G.erased HSM.handshake13_m13_encrypted_extensions) 
+//   (fin_msg:G.erased HSM.handshake13_m13_finished)
+//   : flight13_ee_fin
+//   = Mkflight13_ee_fin begin_fin ee_msg fin_msg
 
-let receive_flight13_ee_fin st b from to =
-  let r = parse_hsm13_ee b from in
-  match r with
-  | E.Error _ | E.Correct None ->
-    err_or_insufficient_data r F13_ee_fin st b from to
-  | E.Correct (Some (ee_payload, fin_begin)) ->
-    let r = parse_hsm13_fin b fin_begin in
-    match r with
-    | E.Error _ | E.Correct None ->
-      err_or_insufficient_data r F13_ee_fin st b from to
-    | E.Correct (Some (fin_payload, pos)) ->
-      if pos <> to then E.Error bytes_remain_error
-      else begin
-        reset_incremental_state st;
-        E.Correct (Some (mk_ee_fin fin_begin ee_payload fin_payload))
-      end
+// let receive_flight13_ee_fin st b from to =
+//   let r = parse_hsm13_ee b from in
+//   match r with
+//   | E.Error _ | E.Correct None ->
+//     err_or_insufficient_data r F13_ee_fin st b from to
+//   | E.Correct (Some (ee_payload, fin_begin)) ->
+//     let r = parse_hsm13_fin b fin_begin in
+//     match r with
+//     | E.Error _ | E.Correct None ->
+//       err_or_insufficient_data r F13_ee_fin st b from to
+//     | E.Correct (Some (fin_payload, pos)) ->
+//       if pos <> to then E.Error bytes_remain_error
+//       else begin
+//         reset_incremental_state st;
+//         E.Correct (Some (mk_ee_fin fin_begin ee_payload fin_payload))
+//       end
 
-let receive_flight13_fin st b from to =
-  let r = parse_hsm13_fin b from in
-  match r with
-  | E.Error _ | E.Correct None ->
-    err_or_insufficient_data r F13_fin st b from to
-  | E.Correct (Some (fin_payload, pos)) ->
-    if pos <> to then E.Error bytes_remain_error
-    else begin
-      reset_incremental_state st;
-      E.Correct (Some ({ fin_msg = fin_payload }))
-    end
+// let receive_flight13_fin st b from to =
+//   let r = parse_hsm13_fin b from in
+//   match r with
+//   | E.Error _ | E.Correct None ->
+//     err_or_insufficient_data r F13_fin st b from to
+//   | E.Correct (Some (fin_payload, pos)) ->
+//     if pos <> to then E.Error bytes_remain_error
+//     else begin
+//       reset_incremental_state st;
+//       E.Correct (Some ({ fin_msg = fin_payload }))
+//     end
 
-let receive_flight13_c_cv_fin st b from to =
-  let r = parse_hsm13_c b from in
-  match r with
-  | E.Error _ | E.Correct None ->
-    err_or_insufficient_data r F13_c_cv_fin st b from to
-  | E.Correct (Some (c_payload, cv_begin)) ->
-    let r = parse_hsm13_cv b cv_begin in
-    match r with
-    | E.Error _ | E.Correct None ->
-      err_or_insufficient_data r F13_c_cv_fin st b from to
-    | E.Correct (Some (cv_payload, fin_begin)) ->
-      let r = parse_hsm13_fin b fin_begin in
-      match r with
-      | E.Error _ | E.Correct None ->
-        err_or_insufficient_data r F13_c_cv_fin st b from to
-      | E.Correct (Some (fin_payload, pos)) ->
-        if pos <> to then E.Error bytes_remain_error
-        else begin
-          reset_incremental_state st;
-          E.Correct (Some ({
-            begin_cv = cv_begin;
-            begin_fin = fin_begin;
-            c_msg = c_payload;
-            cv_msg = cv_payload;
-            fin_msg = fin_payload }))
-        end
+// let receive_flight13_c_cv_fin st b from to =
+//   let r = parse_hsm13_c b from in
+//   match r with
+//   | E.Error _ | E.Correct None ->
+//     err_or_insufficient_data r F13_c_cv_fin st b from to
+//   | E.Correct (Some (c_payload, cv_begin)) ->
+//     let r = parse_hsm13_cv b cv_begin in
+//     match r with
+//     | E.Error _ | E.Correct None ->
+//       err_or_insufficient_data r F13_c_cv_fin st b from to
+//     | E.Correct (Some (cv_payload, fin_begin)) ->
+//       let r = parse_hsm13_fin b fin_begin in
+//       match r with
+//       | E.Error _ | E.Correct None ->
+//         err_or_insufficient_data r F13_c_cv_fin st b from to
+//       | E.Correct (Some (fin_payload, pos)) ->
+//         if pos <> to then E.Error bytes_remain_error
+//         else begin
+//           reset_incremental_state st;
+//           E.Correct (Some ({
+//             begin_cv = cv_begin;
+//             begin_fin = fin_begin;
+//             c_msg = c_payload;
+//             cv_msg = cv_payload;
+//             fin_msg = fin_payload }))
+//         end
 
-let receive_flight13_eoed st b from to =
-  let r = parse_hsm13_eoed b from in
-  match r with
-  | E.Error _ | E.Correct None ->
-    err_or_insufficient_data r F13_eoed st b from to
-  | E.Correct (Some (eoed_payload, pos)) ->
-    if pos <> to then E.Error bytes_remain_error
-    else begin
-      reset_incremental_state st;
-      E.Correct (Some ({ eoed_msg = eoed_payload }))
-    end
+// let receive_flight13_eoed st b from to =
+//   let r = parse_hsm13_eoed b from in
+//   match r with
+//   | E.Error _ | E.Correct None ->
+//     err_or_insufficient_data r F13_eoed st b from to
+//   | E.Correct (Some (eoed_payload, pos)) ->
+//     if pos <> to then E.Error bytes_remain_error
+//     else begin
+//       reset_incremental_state st;
+//       E.Correct (Some ({ eoed_msg = eoed_payload }))
+//     end
 
-let receive_flight13_nst st b from to =
-  let r = parse_hsm13_nst b from in
-  match r with
-  | E.Error _ | E.Correct None ->
-    err_or_insufficient_data r F13_nst st b from to
-  | E.Correct (Some (nst_payload, pos)) ->
-    if pos <> to then E.Error bytes_remain_error
-    else begin
-      reset_incremental_state st;
-      E.Correct (Some ({ nst_msg = nst_payload }))
-    end
+// let receive_flight13_nst st b from to =
+//   let r = parse_hsm13_nst b from in
+//   match r with
+//   | E.Error _ | E.Correct None ->
+//     err_or_insufficient_data r F13_nst st b from to
+//   | E.Correct (Some (nst_payload, pos)) ->
+//     if pos <> to then E.Error bytes_remain_error
+//     else begin
+//       reset_incremental_state st;
+//       E.Correct (Some ({ nst_msg = nst_payload }))
+//     end

--- a/src/tls/HSL.Receive.fst
+++ b/src/tls/HSL.Receive.fst
@@ -80,7 +80,7 @@ let parse_hsm13
     forall (m:HSM13.handshake13).
       (HSM13.tag_of_handshake13 m == tag) <==> cl.LP.clens_cond m})
   (acc:LP.accessor gacc)
-  : b:slice -> from:uint_32 ->
+  : b:R.slice -> from:uint_32 ->
     Stack (TLSError.result (option (HSM13R.repr b & uint_32)))
     (requires fun h ->
       B.live h b.LP.base /\
@@ -124,7 +124,7 @@ let err_or_insufficient_data
   (#a:Type) (#t:Type)
   (parse_result:TLSError.result (option a))
   (in_progress:in_progress_flt_t)
-  (st:hsl_state) (b:slice) (from to:uint_32)
+  (st:hsl_state) (b:R.slice) (from to:uint_32)
   : Stack (TLSError.result (option t))
     (requires fun h ->
       B.live h st.inc_st /\ B.live h b.LP.base /\

--- a/src/tls/HSL.Receive.fsti
+++ b/src/tls/HSL.Receive.fsti
@@ -45,8 +45,6 @@ module HSM13R = MITLS.Repr.HSM13
 
 /// HSL main API
 
-type slice = sl:R.slice{v sl.LP.len <= v LP.validator_max_length}
-
 
 /// For incremental parsing, flight receiving functions have
 ///   preconditions on the current in-progress flight
@@ -132,7 +130,7 @@ val create (r:Mem.rgn)
 /// Receive API
 
 unfold
-let basic_pre_post (st:hsl_state) (b:slice) (from to:uint_32) (in_progress:in_progress_flt_t)
+let basic_pre_post (st:hsl_state) (b:R.slice) (from to:uint_32) (in_progress:in_progress_flt_t)
   : HS.mem -> Type0
   = fun h ->
     let open B in let open LP in
@@ -153,14 +151,11 @@ let basic_pre_post (st:hsl_state) (b:slice) (from to:uint_32) (in_progress:in_pr
     (in_progress_flt st h == F_none \/ in_progress_flt st h == in_progress)
 
 
-let valid_flight_t 'a =
-  (flt:'a) -> (from:uint_32) -> (to:uint_32) -> (b:slice) -> (h:HS.mem) -> Type0
-
 unfold private
 let receive_post
   (#flt:Type)
   (st:hsl_state)
-  (b:slice)
+  (b:R.slice)
   (from to:uint_32)
   (in_progress:in_progress_flt_t)
   (valid:flt -> HS.mem -> Type0)
@@ -192,7 +187,7 @@ let receive_post
 (****** Flight [ EncryptedExtensions; Certificate13; CertificateVerify; Finished ] ******)
 
 noeq
-type flight13_ee_c_cv_fin (b:slice) (from to:uint_32) = {
+type flight13_ee_c_cv_fin (b:R.slice) (from to:uint_32) = {
   ee_msg  : HSM13R.repr b;
   c_msg   : HSM13R.repr b;
   cv_msg  : HSM13R.repr b;
@@ -210,7 +205,7 @@ type flight13_ee_c_cv_fin (b:slice) (from to:uint_32) = {
 }
 
 let valid_flight13_ee_c_cv_fin
-  (#b:slice) (#from #to:uint_32)
+  (#b:R.slice) (#from #to:uint_32)
   (flt:flight13_ee_c_cv_fin b from to) (h:HS.mem)
   = R.valid flt.ee_msg h /\
     R.valid flt.c_msg h /\
@@ -218,7 +213,7 @@ let valid_flight13_ee_c_cv_fin
     R.valid flt.fin_msg h
 
 val receive_flight13_ee_c_cv_fin
-  (st:hsl_state) (b:slice) (from to:uint_32)
+  (st:hsl_state) (b:R.slice) (from to:uint_32)
   : ST (TLSError.result (option (flight13_ee_c_cv_fin b from to)))
        (requires basic_pre_post st b from to F13_ee_c_cv_fin)
        (ensures  receive_post st b from to F13_ee_c_cv_fin valid_flight13_ee_c_cv_fin)

--- a/src/tls/HSL.Receive.fsti
+++ b/src/tls/HSL.Receive.fsti
@@ -15,17 +15,19 @@ open HSL.Common
 
 module HSM = HandshakeMessages
 
+module Repr = MITLS.Repr
+
+module EE_repr = MITLS.Repr.EncryptedExtensions
+module C13_repr = MITLS.Repr.Certificate13
+module CV13_repr = MITLS.Repr.CertificateVerify13
+module Fin13_repr = MITLS.Repr.Finished13
+
 #reset-options "--max_fuel 0 --max_ifuel 0 --using_facts_from '* -FStar.Tactics -FStar.Reflection'"
 
 
 /// HSL main API
 
-type slice =
-  sl:LP.slice
-       (LP.srel_of_buffer_srel (B.trivial_preorder LP.byte))
-       (LP.srel_of_buffer_srel (B.trivial_preorder LP.byte)){
-         v sl.LP.len <= v LP.validator_max_length
-     }
+type slice = sl:Repr.slice{v sl.LP.len <= v LP.validator_max_length}
 
 
 /// For incremental parsing, flight receiving functions have
@@ -111,8 +113,6 @@ val create (r:Mem.rgn)
 
 /// Receive API
 
-#push-options "--max_ifuel 2 --initial_ifuel 2 --z3rlimit 20"  //increase ifuel for inverting options and tuples
-
 unfold
 let basic_pre_post (st:hsl_state) (b:slice) (from to:uint_32) (in_progress:in_progress_flt_t)
   : HS.mem -> Type0
@@ -139,14 +139,14 @@ let valid_flight_t 'a =
   (flt:'a) -> (from:uint_32) -> (to:uint_32) -> (b:slice) -> (h:HS.mem) -> Type0
 
 unfold private
-let receive_post 
+let receive_post
+  (#flt:Type)
   (st:hsl_state)
   (b:slice)
   (from to:uint_32)
-  (f:valid_flight_t 'a)
   (in_progress:in_progress_flt_t)
   (h0:HS.mem)
-  (x:TLSError.result (option 'a))
+  (x:TLSError.result (option flt))
   (h1:HS.mem)
   = basic_pre_post st b from to in_progress h0 /\
     B.modifies (footprint st) h0 h1 /\
@@ -157,12 +157,10 @@ let receive_post
        in_progress_flt st h1 == in_progress /\
        parsed_bytes st h1 ==
          Seq.slice (B.as_seq h0 b.LP.base) (v from) (v to)
-     | Correct (Some flt) ->
-       f flt from to b h1 /\
+     | Correct (Some _) ->
        parsed_bytes st h1 == Seq.empty /\
        in_progress_flt st h1 == F_none
      | _ -> False)
-#pop-options //remove the increased ifuel
 
 
 /// ad-hoc flight types
@@ -170,193 +168,171 @@ let receive_post
 
 /// First 13 flights
 
-/// Common function for slice being a valid 13 message msg
-
-let valid_parsing13
-  (msg:HSM.handshake13)
-  (buf:slice)
-  (from to:uint_32)
-  (h:HS.mem)
-  = let parser = HSM.handshake13_parser in
-    from <= to /\
-    LP.valid parser h buf from /\
-    LP.contents parser h buf from == msg /\
-    LP.content_length parser h buf from == UInt32.v (to - from)
-
 
 (****** Flight [ EncryptedExtensions; Certificate13; CertificateVerify; Finished ] ******)
 
 noeq
-type flight13_ee_c_cv_fin = {
-  begin_c   : uint_32;
-  begin_cv  : uint_32;
-  begin_fin : uint_32;
-
-  ee_msg  : G.erased HSM.handshake13_m13_encrypted_extensions;
-  c_msg   : G.erased HSM.handshake13_m13_certificate;
-  cv_msg  : G.erased HSM.handshake13_m13_certificate_verify;
-  fin_msg : G.erased HSM.handshake13_m13_finished
+type flight13_ee_c_cv_fin (b:slice) (from to:uint_32) = {
+  ee_msg  : EE_repr.repr b;
+  cv_msg  : CV13_repr.repr b;
+  c_msg   : C13_repr.repr b;
+  fin_msg : m:Fin13_repr.repr b{
+    ee_msg.Repr.start_pos    == from /\
+    ee_msg.Repr.end_pos == cv_msg.Repr.start_pos /\
+    cv_msg.Repr.end_pos == c_msg.Repr.start_pos /\
+    c_msg.Repr.end_pos  == m.Repr.start_pos /\
+    m.Repr.end_pos == to
+  }
 }
-
-
-let valid_flight13_ee_c_cv_fin
-  : valid_flight_t flight13_ee_c_cv_fin
-  = fun (flt:flight13_ee_c_cv_fin) (from to:uint_32) (b:slice) (h:HS.mem) ->
-
-    valid_parsing13 (HSM.M13_encrypted_extensions (G.reveal flt.ee_msg)) b from flt.begin_c h /\
-    valid_parsing13 (HSM.M13_certificate (G.reveal flt.c_msg)) b flt.begin_c flt.begin_cv h /\
-    valid_parsing13 (HSM.M13_certificate_verify (G.reveal flt.cv_msg)) b flt.begin_cv flt.begin_fin h /\
-    valid_parsing13 (HSM.M13_finished (G.reveal flt.fin_msg)) b flt.begin_fin to h
-
 
 val receive_flight13_ee_c_cv_fin
   (st:hsl_state) (b:slice) (from to:uint_32)
-  : ST (TLSError.result (option flight13_ee_c_cv_fin))
+  : ST (TLSError.result (option (flight13_ee_c_cv_fin b from to)))
        (requires basic_pre_post st b from to F13_ee_c_cv_fin)
-       (ensures  receive_post st b from to valid_flight13_ee_c_cv_fin F13_ee_c_cv_fin)
+       (ensures  receive_post st b from to F13_ee_c_cv_fin)
 
 
-(****** Flight [EncryptedExtensions; Certificaterequest13; Certificate13; CertificateVerify; Finished ] ******)
+// (****** Flight [EncryptedExtensions; Certificaterequest13; Certificate13; CertificateVerify; Finished ] ******)
 
-noeq
-type flight13_ee_cr_c_cv_fin = {
-  begin_cr  : uint_32;
-  begin_c   : uint_32;
-  begin_cv  : uint_32;
-  begin_fin : uint_32;
+// noeq
+// type flight13_ee_cr_c_cv_fin = {
+//   begin_cr  : uint_32;
+//   begin_c   : uint_32;
+//   begin_cv  : uint_32;
+//   begin_fin : uint_32;
 
-  ee_msg  : G.erased HSM.handshake13_m13_encrypted_extensions;
-  cr_msg  : G.erased HSM.handshake13_m13_certificate_request;
-  c_msg   : G.erased HSM.handshake13_m13_certificate;
-  cv_msg  : G.erased HSM.handshake13_m13_certificate_verify;
-  fin_msg : G.erased HSM.handshake13_m13_finished
-}
-
-
-let valid_flight13_ee_cr_c_cv_fin
-  : valid_flight_t flight13_ee_cr_c_cv_fin
-  = fun (flt:flight13_ee_cr_c_cv_fin) (from to:uint_32) (b:slice) (h:HS.mem) ->
-
-    valid_parsing13 (HSM.M13_encrypted_extensions (G.reveal flt.ee_msg)) b from flt.begin_cr h /\
-    valid_parsing13 (HSM.M13_certificate_request (G.reveal flt.cr_msg)) b flt.begin_cr flt.begin_c h /\
-    valid_parsing13 (HSM.M13_certificate (G.reveal flt.c_msg)) b flt.begin_c flt.begin_cv h /\
-    valid_parsing13 (HSM.M13_certificate_verify (G.reveal flt.cv_msg)) b flt.begin_cv flt.begin_fin h /\
-    valid_parsing13 (HSM.M13_finished (G.reveal flt.fin_msg)) b flt.begin_fin to h
+//   ee_msg  : G.erased HSM.handshake13_m13_encrypted_extensions;
+//   cr_msg  : G.erased HSM.handshake13_m13_certificate_request;
+//   c_msg   : G.erased HSM.handshake13_m13_certificate;
+//   cv_msg  : G.erased HSM.handshake13_m13_certificate_verify;
+//   fin_msg : G.erased HSM.handshake13_m13_finished
+// }
 
 
-val receive_flight13_ee_cr_c_cv_fin
-  (st:hsl_state) (b:slice) (from to:uint_32)
-  : ST (TLSError.result (option flight13_ee_cr_c_cv_fin))
-       (requires basic_pre_post st b from to F13_ee_cr_c_cv_fin)
-       (ensures  receive_post st b from to valid_flight13_ee_cr_c_cv_fin F13_ee_cr_c_cv_fin)
+// let valid_flight13_ee_cr_c_cv_fin
+//   : valid_flight_t flight13_ee_cr_c_cv_fin
+//   = fun (flt:flight13_ee_cr_c_cv_fin) (from to:uint_32) (b:slice) (h:HS.mem) ->
+
+//     valid_parsing13 (HSM.M13_encrypted_extensions (G.reveal flt.ee_msg)) b from flt.begin_cr h /\
+//     valid_parsing13 (HSM.M13_certificate_request (G.reveal flt.cr_msg)) b flt.begin_cr flt.begin_c h /\
+//     valid_parsing13 (HSM.M13_certificate (G.reveal flt.c_msg)) b flt.begin_c flt.begin_cv h /\
+//     valid_parsing13 (HSM.M13_certificate_verify (G.reveal flt.cv_msg)) b flt.begin_cv flt.begin_fin h /\
+//     valid_parsing13 (HSM.M13_finished (G.reveal flt.fin_msg)) b flt.begin_fin to h
 
 
-(****** Flight [EncryptedExtensions; Finished] ******)
-
-noeq
-type flight13_ee_fin = {
-  begin_fin : uint_32;
-
-  ee_msg    : G.erased HSM.handshake13_m13_encrypted_extensions;
-  fin_msg   : G.erased HSM.handshake13_m13_finished
-}
-
-let valid_flight13_ee_fin : valid_flight_t flight13_ee_fin =
-  fun (flt:flight13_ee_fin) (from to:uint_32) (b:slice) (h:HS.mem) ->
-
-  valid_parsing13 (HSM.M13_encrypted_extensions (G.reveal flt.ee_msg)) b from flt.begin_fin h /\
-  valid_parsing13 (HSM.M13_finished (G.reveal flt.fin_msg)) b flt.begin_fin to h
-
-val receive_flight13_ee_fin (st:hsl_state) (b:slice) (from to:uint_32)
-  : ST (TLSError.result (option flight13_ee_fin))
-       (requires basic_pre_post st b from to F13_ee_fin)
-       (ensures  receive_post st b from to valid_flight13_ee_fin F13_ee_fin)
+// val receive_flight13_ee_cr_c_cv_fin
+//   (st:hsl_state) (b:slice) (from to:uint_32)
+//   : ST (TLSError.result (option flight13_ee_cr_c_cv_fin))
+//        (requires basic_pre_post st b from to F13_ee_cr_c_cv_fin)
+//        (ensures  receive_post st b from to valid_flight13_ee_cr_c_cv_fin F13_ee_cr_c_cv_fin)
 
 
-(****** Flight [ Finished ] ******)
+// (****** Flight [EncryptedExtensions; Finished] ******)
 
-noeq
-type flight13_fin = {
-  fin_msg : G.erased HSM.handshake13_m13_finished
-}
+// noeq
+// type flight13_ee_fin = {
+//   begin_fin : uint_32;
 
+//   ee_msg    : G.erased HSM.handshake13_m13_encrypted_extensions;
+//   fin_msg   : G.erased HSM.handshake13_m13_finished
+// }
 
-let valid_flight13_fin : valid_flight_t flight13_fin =
-  fun (flt:flight13_fin) (from to:uint_32) (b:slice) (h:HS.mem) ->
+// let valid_flight13_ee_fin : valid_flight_t flight13_ee_fin =
+//   fun (flt:flight13_ee_fin) (from to:uint_32) (b:slice) (h:HS.mem) ->
 
-  valid_parsing13 (HSM.M13_finished (G.reveal flt.fin_msg)) b from to h
+//   valid_parsing13 (HSM.M13_encrypted_extensions (G.reveal flt.ee_msg)) b from flt.begin_fin h /\
+//   valid_parsing13 (HSM.M13_finished (G.reveal flt.fin_msg)) b flt.begin_fin to h
 
-val receive_flight13_fin (st:hsl_state) (b:slice) (from to:uint_32)
-  : ST (TLSError.result (option flight13_fin))
-       (requires basic_pre_post st b from to F13_fin)
-       (ensures  receive_post st b from to valid_flight13_fin F13_fin)
-
-
-(****** Flight [ Certificate13; CertificateVerify; Finished ] ******)
-
-noeq
-type flight13_c_cv_fin = {
-  begin_cv  : uint_32;
-  begin_fin : uint_32;
-
-  c_msg   : G.erased HSM.handshake13_m13_certificate;
-  cv_msg  : G.erased HSM.handshake13_m13_certificate_verify;
-  fin_msg : G.erased HSM.handshake13_m13_finished
-}
+// val receive_flight13_ee_fin (st:hsl_state) (b:slice) (from to:uint_32)
+//   : ST (TLSError.result (option flight13_ee_fin))
+//        (requires basic_pre_post st b from to F13_ee_fin)
+//        (ensures  receive_post st b from to valid_flight13_ee_fin F13_ee_fin)
 
 
-let valid_flight13_c_cv_fin
-  : valid_flight_t flight13_c_cv_fin
-  = fun (flt:flight13_c_cv_fin) (from to:uint_32) (b:slice) (h:HS.mem) ->
+// (****** Flight [ Finished ] ******)
 
-    valid_parsing13 (HSM.M13_certificate (G.reveal flt.c_msg)) b from flt.begin_cv h /\
-    valid_parsing13 (HSM.M13_certificate_verify (G.reveal flt.cv_msg)) b flt.begin_cv flt.begin_fin h /\
-    valid_parsing13 (HSM.M13_finished (G.reveal flt.fin_msg)) b flt.begin_fin to h
-
-
-val receive_flight13_c_cv_fin
-  (st:hsl_state) (b:slice) (from to:uint_32)
-  : ST (TLSError.result (option flight13_c_cv_fin))
-       (requires basic_pre_post st b from to F13_c_cv_fin)
-       (ensures  receive_post st b from to valid_flight13_c_cv_fin F13_c_cv_fin)
+// noeq
+// type flight13_fin = {
+//   fin_msg : G.erased HSM.handshake13_m13_finished
+// }
 
 
-(****** Flight [ EndOfEarlyData ] ******)
+// let valid_flight13_fin : valid_flight_t flight13_fin =
+//   fun (flt:flight13_fin) (from to:uint_32) (b:slice) (h:HS.mem) ->
 
-noeq
-type flight13_eoed = {
-  eoed_msg : G.erased (HSM.handshake13_m13_end_of_early_data)
-}
+//   valid_parsing13 (HSM.M13_finished (G.reveal flt.fin_msg)) b from to h
 
-
-let valid_flight13_eoed : valid_flight_t flight13_eoed =
-  fun (flt:flight13_eoed) (from to:uint_32) (b:slice) (h:HS.mem) ->
-
-  valid_parsing13 (HSM.M13_end_of_early_data (G.reveal flt.eoed_msg)) b from to h
-
-val receive_flight13_eoed (st:hsl_state) (b:slice) (from to:uint_32)
-  : ST (TLSError.result (option flight13_eoed))
-       (requires basic_pre_post st b from to F13_eoed)
-       (ensures  receive_post st b from to valid_flight13_eoed F13_eoed)
+// val receive_flight13_fin (st:hsl_state) (b:slice) (from to:uint_32)
+//   : ST (TLSError.result (option flight13_fin))
+//        (requires basic_pre_post st b from to F13_fin)
+//        (ensures  receive_post st b from to valid_flight13_fin F13_fin)
 
 
-(****** Flight [ NewSessionTicket13 ] ******)
+// (****** Flight [ Certificate13; CertificateVerify; Finished ] ******)
 
-noeq
-type flight13_nst = {
-  nst_msg : G.erased (HSM.handshake13_m13_new_session_ticket)
-}
+// noeq
+// type flight13_c_cv_fin = {
+//   begin_cv  : uint_32;
+//   begin_fin : uint_32;
 
-
-let valid_flight13_nst : valid_flight_t flight13_nst =
-  fun (flt:flight13_nst) (from to:uint_32) (b:slice) (h:HS.mem) ->
-
-  valid_parsing13 (HSM.M13_new_session_ticket (G.reveal flt.nst_msg)) b from to h
-
-val receive_flight13_nst (st:hsl_state) (b:slice) (from to:uint_32)
-  : ST (TLSError.result (option flight13_nst))
-       (requires basic_pre_post st b from to F13_nst)
-       (ensures  receive_post st b from to valid_flight13_nst F13_nst)
+//   c_msg   : G.erased HSM.handshake13_m13_certificate;
+//   cv_msg  : G.erased HSM.handshake13_m13_certificate_verify;
+//   fin_msg : G.erased HSM.handshake13_m13_finished
+// }
 
 
-/// TODO: 12 flights
+// let valid_flight13_c_cv_fin
+//   : valid_flight_t flight13_c_cv_fin
+//   = fun (flt:flight13_c_cv_fin) (from to:uint_32) (b:slice) (h:HS.mem) ->
+
+//     valid_parsing13 (HSM.M13_certificate (G.reveal flt.c_msg)) b from flt.begin_cv h /\
+//     valid_parsing13 (HSM.M13_certificate_verify (G.reveal flt.cv_msg)) b flt.begin_cv flt.begin_fin h /\
+//     valid_parsing13 (HSM.M13_finished (G.reveal flt.fin_msg)) b flt.begin_fin to h
+
+
+// val receive_flight13_c_cv_fin
+//   (st:hsl_state) (b:slice) (from to:uint_32)
+//   : ST (TLSError.result (option flight13_c_cv_fin))
+//        (requires basic_pre_post st b from to F13_c_cv_fin)
+//        (ensures  receive_post st b from to valid_flight13_c_cv_fin F13_c_cv_fin)
+
+
+// (****** Flight [ EndOfEarlyData ] ******)
+
+// noeq
+// type flight13_eoed = {
+//   eoed_msg : G.erased (HSM.handshake13_m13_end_of_early_data)
+// }
+
+
+// let valid_flight13_eoed : valid_flight_t flight13_eoed =
+//   fun (flt:flight13_eoed) (from to:uint_32) (b:slice) (h:HS.mem) ->
+
+//   valid_parsing13 (HSM.M13_end_of_early_data (G.reveal flt.eoed_msg)) b from to h
+
+// val receive_flight13_eoed (st:hsl_state) (b:slice) (from to:uint_32)
+//   : ST (TLSError.result (option flight13_eoed))
+//        (requires basic_pre_post st b from to F13_eoed)
+//        (ensures  receive_post st b from to valid_flight13_eoed F13_eoed)
+
+
+// (****** Flight [ NewSessionTicket13 ] ******)
+
+// noeq
+// type flight13_nst = {
+//   nst_msg : G.erased (HSM.handshake13_m13_new_session_ticket)
+// }
+
+
+// let valid_flight13_nst : valid_flight_t flight13_nst =
+//   fun (flt:flight13_nst) (from to:uint_32) (b:slice) (h:HS.mem) ->
+
+//   valid_parsing13 (HSM.M13_new_session_ticket (G.reveal flt.nst_msg)) b from to h
+
+// val receive_flight13_nst (st:hsl_state) (b:slice) (from to:uint_32)
+//   : ST (TLSError.result (option flight13_nst))
+//        (requires basic_pre_post st b from to F13_nst)
+//        (ensures  receive_post st b from to valid_flight13_nst F13_nst)
+
+
+// /// TODO: 12 flights

--- a/src/tls/MITLS.Repr.Certificate13.fst
+++ b/src/tls/MITLS.Repr.Certificate13.fst
@@ -31,9 +31,9 @@ module R = MITLS.Repr
 open FStar.Integers
 open FStar.HyperStack.ST
 
-module HSM13 = Parsers.Handshake13
+module C13 = Parsers.Certificate13
 
-let t = HSM13.handshake13_m13_certificate
+let t = C13.certificate13
 
 let repr (b:R.slice) =
-  R.repr_p t b HSM13.handshake13_m13_certificate_parser
+  R.repr_p t b C13.certificate13_parser

--- a/src/tls/MITLS.Repr.Certificate13.fst
+++ b/src/tls/MITLS.Repr.Certificate13.fst
@@ -1,0 +1,38 @@
+(*
+  Copyright 2015--2019 INRIA and Microsoft Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Authors: T. Ramananandro, A. Rastogi, N. Swamy
+*)
+module MITLS.Repr.Certificate13
+(* Summary:
+
+   This module encapsulates wire-format representations of
+   Parsers.Certificate13 messages.
+
+   Its main type, `repr b` is an instance of MITLS.Repr.repr
+   instantiated with certificate13_parser
+*)
+module LP = LowParse.Low.Base
+module B = LowStar.Monotonic.Buffer
+module HS = FStar.HyperStack
+module R = MITLS.Repr
+module C13 = Parsers.Certificate13
+open FStar.Integers
+open FStar.HyperStack.ST
+
+let t = C13.certificate13
+
+let repr (b:R.slice) =
+  R.repr_p t b C13.certificate13_parser

--- a/src/tls/MITLS.Repr.Certificate13.fst
+++ b/src/tls/MITLS.Repr.Certificate13.fst
@@ -19,20 +19,21 @@ module MITLS.Repr.Certificate13
 (* Summary:
 
    This module encapsulates wire-format representations of
-   Parsers.Certificate13 messages.
+   Parsers.Handshake13.handshake13_m13_certificate messages
 
    Its main type, `repr b` is an instance of MITLS.Repr.repr
-   instantiated with certificate13_parser
+   instantiated with handshake13_m13_certificate_parser
 *)
 module LP = LowParse.Low.Base
 module B = LowStar.Monotonic.Buffer
 module HS = FStar.HyperStack
 module R = MITLS.Repr
-module C13 = Parsers.Certificate13
 open FStar.Integers
 open FStar.HyperStack.ST
 
-let t = C13.certificate13
+module HSM13 = Parsers.Handshake13
+
+let t = HSM13.handshake13_m13_certificate
 
 let repr (b:R.slice) =
-  R.repr_p t b C13.certificate13_parser
+  R.repr_p t b HSM13.handshake13_m13_certificate_parser

--- a/src/tls/MITLS.Repr.CertificateVerify13.fst
+++ b/src/tls/MITLS.Repr.CertificateVerify13.fst
@@ -31,9 +31,9 @@ module R = MITLS.Repr
 open FStar.Integers
 open FStar.HyperStack.ST
 
-module HSM13 = Parsers.Handshake13
+module CV13 = Parsers.CertificateVerify13
 
-let t = HSM13.handshake13_m13_certificate_verify
+let t = CV13.certificateVerify13
 
 let repr (b:R.slice) =
-  R.repr_p t b HSM13.handshake13_m13_certificate_verify_parser
+  R.repr_p t b CV13.certificateVerify13_parser

--- a/src/tls/MITLS.Repr.CertificateVerify13.fst
+++ b/src/tls/MITLS.Repr.CertificateVerify13.fst
@@ -19,21 +19,21 @@ module MITLS.Repr.CertificateVerify13
 (* Summary:
 
    This module encapsulates wire-format representations of
-   Parsers.CertificateVerify13 messages.
+   Parsers.Handshake13.handshake13_m13_certificate_verify messages.
 
    Its main type, `repr b` is an instance of MITLS.Repr.repr
-   instantiated with certificateVerify13_parser
+   instantiated with handshake13_m13_certificate_verify_parser
 *)
 module LP = LowParse.Low.Base
 module B = LowStar.Monotonic.Buffer
 module HS = FStar.HyperStack
 module R = MITLS.Repr
-module CV13 = Parsers.CertificateVerify13
 open FStar.Integers
 open FStar.HyperStack.ST
 
-let t = CV13.certificateVerify13
+module HSM13 = Parsers.Handshake13
+
+let t = HSM13.handshake13_m13_certificate_verify
 
 let repr (b:R.slice) =
-  R.repr_p t b CV13.certificateVerify13_parser
- 
+  R.repr_p t b HSM13.handshake13_m13_certificate_verify_parser

--- a/src/tls/MITLS.Repr.CertificateVerify13.fst
+++ b/src/tls/MITLS.Repr.CertificateVerify13.fst
@@ -1,0 +1,39 @@
+(*
+  Copyright 2015--2019 INRIA and Microsoft Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Authors: T. Ramananandro, A. Rastogi, N. Swamy
+*)
+module MITLS.Repr.CertificateVerify13
+(* Summary:
+
+   This module encapsulates wire-format representations of
+   Parsers.CertificateVerify13 messages.
+
+   Its main type, `repr b` is an instance of MITLS.Repr.repr
+   instantiated with certificateVerify13_parser
+*)
+module LP = LowParse.Low.Base
+module B = LowStar.Monotonic.Buffer
+module HS = FStar.HyperStack
+module R = MITLS.Repr
+module CV13 = Parsers.CertificateVerify13
+open FStar.Integers
+open FStar.HyperStack.ST
+
+let t = CV13.certificateVerify13
+
+let repr (b:R.slice) =
+  R.repr_p t b CV13.certificateVerify13_parser
+ 

--- a/src/tls/MITLS.Repr.EncryptedExtensions.fst
+++ b/src/tls/MITLS.Repr.EncryptedExtensions.fst
@@ -31,9 +31,9 @@ module R = MITLS.Repr
 open FStar.Integers
 open FStar.HyperStack.ST
 
-module HSM13 = Parsers.Handshake13
+module EE = Parsers.EncryptedExtensions
 
-let t = HSM13.handshake13_m13_encrypted_extensions
+let t = EE.encryptedExtensions
 
 let repr (b:R.slice) =
-  R.repr_p t b HSM13.handshake13_m13_encrypted_extensions_parser
+  R.repr_p t b EE.encryptedExtensions_parser

--- a/src/tls/MITLS.Repr.EncryptedExtensions.fst
+++ b/src/tls/MITLS.Repr.EncryptedExtensions.fst
@@ -19,7 +19,7 @@ module MITLS.Repr.EncryptedExtensions
 (* Summary:
 
    This module encapsulates wire-format representations of
-   Parsers.Handshake13_m13_encrypted_extensions messages.
+   Parsers.Handshake13.handshake13_m13_encrypted_extensions messages
 
    Its main type, `repr b` is an instance of MITLS.Repr.repr
    instantiated with handshake13_m13_encrypted_extensions_parser
@@ -28,11 +28,12 @@ module LP = LowParse.Low.Base
 module B = LowStar.Monotonic.Buffer
 module HS = FStar.HyperStack
 module R = MITLS.Repr
-module EE = Parsers.EncryptedExtensions
 open FStar.Integers
 open FStar.HyperStack.ST
 
-let t = EE.encryptedExtensions
+module HSM13 = Parsers.Handshake13
+
+let t = HSM13.handshake13_m13_encrypted_extensions
 
 let repr (b:R.slice) =
-  R.repr_p t b EE.encryptedExtensions_parser
+  R.repr_p t b HSM13.handshake13_m13_encrypted_extensions_parser

--- a/src/tls/MITLS.Repr.EncryptedExtensions.fst
+++ b/src/tls/MITLS.Repr.EncryptedExtensions.fst
@@ -1,0 +1,38 @@
+(*
+  Copyright 2015--2019 INRIA and Microsoft Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Authors: T. Ramananandro, A. Rastogi, N. Swamy
+*)
+module MITLS.Repr.EncryptedExtensions
+(* Summary:
+
+   This module encapsulates wire-format representations of
+   Parsers.Handshake13_m13_encrypted_extensions messages.
+
+   Its main type, `repr b` is an instance of MITLS.Repr.repr
+   instantiated with handshake13_m13_encrypted_extensions_parser
+*)
+module LP = LowParse.Low.Base
+module B = LowStar.Monotonic.Buffer
+module HS = FStar.HyperStack
+module R = MITLS.Repr
+module EE = Parsers.EncryptedExtensions
+open FStar.Integers
+open FStar.HyperStack.ST
+
+let t = EE.encryptedExtensions
+
+let repr (b:R.slice) =
+  R.repr_p t b EE.encryptedExtensions_parser

--- a/src/tls/MITLS.Repr.Finished13.fst
+++ b/src/tls/MITLS.Repr.Finished13.fst
@@ -37,4 +37,3 @@ let t = HSM13.handshake13_m13_finished
 
 let repr (b:R.slice) =
   R.repr_p t b HSM13.handshake13_m13_finished_parser
-

--- a/src/tls/MITLS.Repr.Finished13.fst
+++ b/src/tls/MITLS.Repr.Finished13.fst
@@ -19,7 +19,7 @@ module MITLS.Repr.Finished13
 (* Summary:
 
    This module encapsulates wire-format representations of
-   Parsers.CertificateVerify13 messages.
+   Parsers.Handshake13.handshake13_m13_finished messges
 
    Its main type, `repr b` is an instance of MITLS.Repr.repr
    instantiated with certificateVerify13_parser
@@ -28,12 +28,13 @@ module LP = LowParse.Low.Base
 module B = LowStar.Monotonic.Buffer
 module HS = FStar.HyperStack
 module R = MITLS.Repr
-module Fin13 = Parsers.Handshake13_m13_finished
 open FStar.Integers
 open FStar.HyperStack.ST
 
-let t = Fin13.handshake13_m13_finished
+module HSM13 = Parsers.Handshake13
+
+let t = HSM13.handshake13_m13_finished
 
 let repr (b:R.slice) =
-  R.repr_p t b Fin13.handshake13_m13_finished_parser
- 
+  R.repr_p t b HSM13.handshake13_m13_finished_parser
+

--- a/src/tls/MITLS.Repr.Finished13.fst
+++ b/src/tls/MITLS.Repr.Finished13.fst
@@ -1,0 +1,39 @@
+(*
+  Copyright 2015--2019 INRIA and Microsoft Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Authors: T. Ramananandro, A. Rastogi, N. Swamy
+*)
+module MITLS.Repr.Finished13
+(* Summary:
+
+   This module encapsulates wire-format representations of
+   Parsers.CertificateVerify13 messages.
+
+   Its main type, `repr b` is an instance of MITLS.Repr.repr
+   instantiated with certificateVerify13_parser
+*)
+module LP = LowParse.Low.Base
+module B = LowStar.Monotonic.Buffer
+module HS = FStar.HyperStack
+module R = MITLS.Repr
+module Fin13 = Parsers.Handshake13_m13_finished
+open FStar.Integers
+open FStar.HyperStack.ST
+
+let t = Fin13.handshake13_m13_finished
+
+let repr (b:R.slice) =
+  R.repr_p t b Fin13.handshake13_m13_finished_parser
+ 

--- a/src/tls/MITLS.Repr.HSM13.fst
+++ b/src/tls/MITLS.Repr.HSM13.fst
@@ -100,42 +100,48 @@ unfold let repr_post
     r.start_pos <= rr.start_pos /\  //slice indices for the instance repr are contained in the slice indices of r ...
     rr.end_pos <= r.end_pos  //... useful for framing
 
+private let get_repr_common (#b:R.slice) (r:repr b)
+  (#a:Type) (#k:R.strong_parser_kind)
+  (#p:LP.parser k a) (#cl:LP.clens HSM13.handshake13 a)
+  (#gacc:LP.gaccessor HSM13.handshake13_parser p cl)
+  (acc:LP.accessor gacc) (validator:LP.validator p)
+  = let m_begin = acc b r.R.start_pos in
+    let m_end = validator b m_begin in
+
+    R.mk b m_begin m_end p
+  
 let get_ee_repr (#b:R.slice) (r:repr b{is_ee r})
   : Stack (EERepr.repr b)
     (requires repr_pre r)
     (ensures  repr_post r HSM13.M13_encrypted_extensions)
   = R.reveal_valid ();
-    let ee_begin = HSM13.handshake13_accessor_encrypted_extensions b r.R.start_pos in
-    let ee_end = HSM13.handshake13_m13_encrypted_extensions_validator b ee_begin in
-
-    R.mk b ee_begin ee_end HSM13.handshake13_m13_encrypted_extensions_parser
+    get_repr_common r
+      HSM13.handshake13_accessor_encrypted_extensions
+      HSM13.handshake13_m13_encrypted_extensions_validator
 
 let get_c_repr (#b:R.slice) (r:repr b{is_c r})
   : Stack (CRepr.repr b)
     (requires repr_pre r)
     (ensures  repr_post r HSM13.M13_certificate)
   = R.reveal_valid ();
-    let c_begin = HSM13.handshake13_accessor_certificate b r.R.start_pos in
-    let c_end = HSM13.handshake13_m13_certificate_validator b c_begin in
-    
-    R.mk b c_begin c_end HSM13.handshake13_m13_certificate_parser
+    get_repr_common r 
+      HSM13.handshake13_accessor_certificate
+      HSM13.handshake13_m13_certificate_validator
 
 let get_cv_repr (#b:R.slice) (r:repr b{is_cv r})
   : Stack (CVRepr.repr b)
     (requires repr_pre r)
     (ensures  repr_post r HSM13.M13_certificate_verify)
   = R.reveal_valid ();
-    let cv_begin = HSM13.handshake13_accessor_certificate_verify b r.R.start_pos in
-    let cv_end = HSM13.handshake13_m13_certificate_verify_validator b cv_begin in
-
-    R.mk b cv_begin cv_end HSM13.handshake13_m13_certificate_verify_parser
+    get_repr_common r
+      HSM13.handshake13_accessor_certificate_verify
+      HSM13.handshake13_m13_certificate_verify_validator
 
 let get_fin_repr (#b:R.slice) (r:repr b{is_fin r})
   : Stack (FinRepr.repr b)
     (requires repr_pre r)
     (ensures  repr_post r HSM13.M13_finished)
   = R.reveal_valid ();
-    let f_begin = HSM13.handshake13_accessor_finished b r.R.start_pos in
-    let f_end = HSM13.handshake13_m13_finished_validator b f_begin in
-    
-    R.mk b f_begin f_end HSM13.handshake13_m13_finished_parser
+    get_repr_common r
+      HSM13.handshake13_accessor_finished
+      HSM13.handshake13_m13_finished_validator

--- a/src/tls/MITLS.Repr.HSM13.fst
+++ b/src/tls/MITLS.Repr.HSM13.fst
@@ -97,8 +97,8 @@ unfold let repr_post
     B.(modifies loc_none h0 h1) /\
     valid rr h1 /\  //the returned repr is valid in h1
     value r == f (value rr) /\  //relation between the values of the two reprs
-    r.start_pos <= rr.start_pos /\  //slice indices for the instance repr are contained in the slice indices of r
-    r.end_pos == rr.end_pos
+    r.start_pos <= rr.start_pos /\  //slice indices for the instance repr are contained in the slice indices of r ...
+    rr.end_pos <= r.end_pos  //... useful for framing
 
 let get_ee_repr (#b:R.slice) (r:repr b{is_ee r})
   : Stack (EERepr.repr b)
@@ -106,11 +106,9 @@ let get_ee_repr (#b:R.slice) (r:repr b{is_ee r})
     (ensures  repr_post r HSM13.M13_encrypted_extensions)
   = R.reveal_valid ();
     let ee_begin = HSM13.handshake13_accessor_encrypted_extensions b r.R.start_pos in
+    let ee_end = HSM13.handshake13_m13_encrypted_extensions_validator b ee_begin in
 
-    let h = ST.get () in
-    assume (v ee_begin + LP.content_length HSM13.handshake13_m13_encrypted_extensions_parser h b ee_begin == v r.R.end_pos);
-
-    R.mk b ee_begin r.R.end_pos HSM13.handshake13_m13_encrypted_extensions_parser
+    R.mk b ee_begin ee_end HSM13.handshake13_m13_encrypted_extensions_parser
 
 let get_c_repr (#b:R.slice) (r:repr b{is_c r})
   : Stack (CRepr.repr b)
@@ -118,23 +116,19 @@ let get_c_repr (#b:R.slice) (r:repr b{is_c r})
     (ensures  repr_post r HSM13.M13_certificate)
   = R.reveal_valid ();
     let c_begin = HSM13.handshake13_accessor_certificate b r.R.start_pos in
+    let c_end = HSM13.handshake13_m13_certificate_validator b c_begin in
     
-    let h = ST.get () in
-    assume (v c_begin + LP.content_length HSM13.handshake13_m13_certificate_parser h b c_begin == v r.R.end_pos);
-    
-    R.mk b c_begin r.R.end_pos HSM13.handshake13_m13_certificate_parser
+    R.mk b c_begin c_end HSM13.handshake13_m13_certificate_parser
 
 let get_cv_repr (#b:R.slice) (r:repr b{is_cv r})
   : Stack (CVRepr.repr b)
     (requires repr_pre r)
     (ensures  repr_post r HSM13.M13_certificate_verify)
   = R.reveal_valid ();
-    let c_begin = HSM13.handshake13_accessor_certificate_verify b r.R.start_pos in
-    
-    let h = ST.get () in
-    assume (v c_begin + LP.content_length HSM13.handshake13_m13_certificate_verify_parser h b c_begin == v r.R.end_pos);
-    
-    R.mk b c_begin r.R.end_pos HSM13.handshake13_m13_certificate_verify_parser
+    let cv_begin = HSM13.handshake13_accessor_certificate_verify b r.R.start_pos in
+    let cv_end = HSM13.handshake13_m13_certificate_verify_validator b cv_begin in
+
+    R.mk b cv_begin cv_end HSM13.handshake13_m13_certificate_verify_parser
 
 let get_fin_repr (#b:R.slice) (r:repr b{is_fin r})
   : Stack (FinRepr.repr b)
@@ -142,8 +136,6 @@ let get_fin_repr (#b:R.slice) (r:repr b{is_fin r})
     (ensures  repr_post r HSM13.M13_finished)
   = R.reveal_valid ();
     let f_begin = HSM13.handshake13_accessor_finished b r.R.start_pos in
+    let f_end = HSM13.handshake13_m13_finished_validator b f_begin in
     
-    let h = ST.get () in
-    assume (v f_begin + LP.content_length HSM13.handshake13_m13_finished_parser h b f_begin == v r.R.end_pos);
-    
-    R.mk b f_begin r.R.end_pos HSM13.handshake13_m13_finished_parser
+    R.mk b f_begin f_end HSM13.handshake13_m13_finished_parser

--- a/src/tls/MITLS.Repr.HSM13.fst
+++ b/src/tls/MITLS.Repr.HSM13.fst
@@ -105,7 +105,8 @@ private let get_repr_common (#b:R.slice) (r:repr b)
   (#p:LP.parser k a) (#cl:LP.clens HSM13.handshake13 a)
   (#gacc:LP.gaccessor HSM13.handshake13_parser p cl)
   (acc:LP.accessor gacc) (validator:LP.validator p)
-  = let m_begin = acc b r.R.start_pos in
+  = R.reveal_valid ();
+    let m_begin = acc b r.R.start_pos in
     let m_end = validator b m_begin in
 
     R.mk b m_begin m_end p
@@ -114,8 +115,7 @@ let get_ee_repr (#b:R.slice) (r:repr b{is_ee r})
   : Stack (EERepr.repr b)
     (requires repr_pre r)
     (ensures  repr_post r HSM13.M13_encrypted_extensions)
-  = R.reveal_valid ();
-    get_repr_common r
+  = get_repr_common r
       HSM13.handshake13_accessor_encrypted_extensions
       HSM13.handshake13_m13_encrypted_extensions_validator
 
@@ -123,8 +123,7 @@ let get_c_repr (#b:R.slice) (r:repr b{is_c r})
   : Stack (CRepr.repr b)
     (requires repr_pre r)
     (ensures  repr_post r HSM13.M13_certificate)
-  = R.reveal_valid ();
-    get_repr_common r 
+  = get_repr_common r 
       HSM13.handshake13_accessor_certificate
       HSM13.handshake13_m13_certificate_validator
 
@@ -132,8 +131,7 @@ let get_cv_repr (#b:R.slice) (r:repr b{is_cv r})
   : Stack (CVRepr.repr b)
     (requires repr_pre r)
     (ensures  repr_post r HSM13.M13_certificate_verify)
-  = R.reveal_valid ();
-    get_repr_common r
+  = get_repr_common r
       HSM13.handshake13_accessor_certificate_verify
       HSM13.handshake13_m13_certificate_verify_validator
 
@@ -141,7 +139,6 @@ let get_fin_repr (#b:R.slice) (r:repr b{is_fin r})
   : Stack (FinRepr.repr b)
     (requires repr_pre r)
     (ensures  repr_post r HSM13.M13_finished)
-  = R.reveal_valid ();
-    get_repr_common r
+  = get_repr_common r
       HSM13.handshake13_accessor_finished
       HSM13.handshake13_m13_finished_validator

--- a/src/tls/MITLS.Repr.HSM13.fst
+++ b/src/tls/MITLS.Repr.HSM13.fst
@@ -1,0 +1,149 @@
+(*
+  Copyright 2015--2019 INRIA and Microsoft Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Authors: T. Ramananandro, A. Rastogi, N. Swamy
+*)
+module MITLS.Repr.HSM13
+
+(*
+ * This module provides a repr for Handshake13 messages
+ *   i.e. Parsers.Handshake13
+ *
+ * It defines predicates for indicating that a repr from
+ *   this module is a specific instance (such as EE or Fin)
+ *
+ * Given such a predicate (and validity of the repr),
+ *   clients can obtain reprs for the instance types
+ *   (e.g. repr for EE or Fin messages)
+ *)
+
+module ST = FStar.HyperStack.ST
+module LP = LowParse.Low.Base
+module B  = LowStar.Buffer
+module HS = FStar.HyperStack
+module R  = MITLS.Repr
+
+open FStar.Integers
+open FStar.HyperStack.ST
+
+module HSM13 = Parsers.Handshake13
+
+module EERepr  = MITLS.Repr.EncryptedExtensions
+module CRepr   = MITLS.Repr.Certificate13
+module CVRepr  = MITLS.Repr.CertificateVerify13
+module FinRepr = MITLS.Repr.Finished13
+
+type t = HSM13.handshake13
+
+type repr (b:R.slice) =
+  R.repr_p t b HSM13.handshake13_parser
+
+let is_eoed (#b:R.slice) (r:repr b) : GTot bool =
+  HSM13.M13_end_of_early_data? (R.value r)
+
+let is_ee (#b:R.slice) (r:repr b) : GTot bool =
+  HSM13.M13_encrypted_extensions? (R.value r)
+
+let is_cr (#b:R.slice) (r:repr b) : GTot bool =
+  HSM13.M13_certificate_request? (R.value r)
+
+let is_c (#b:R.slice) (r:repr b) : GTot bool =
+  HSM13.M13_certificate? (R.value r)
+
+let is_cv (#b:R.slice) (r:repr b) : GTot bool =
+  HSM13.M13_certificate_verify? (R.value r)
+
+let is_fin (#b:R.slice) (r:repr b) : GTot bool =
+  HSM13.M13_finished? (R.value r)
+
+let is_nst (#b:R.slice) (r:repr b) : GTot bool =
+  HSM13.M13_new_session_ticket? (R.value r)
+
+let is_kupd (#b:R.slice) (r:repr b) : GTot bool =
+  HSM13.M13_key_update? (R.value r)
+
+(*
+ * Common precondition for functions that return the
+ *   reprs for specific instance types
+ *)
+unfold let repr_pre (#b:R.slice) (r:repr b)
+  : HS.mem -> Type0
+  = fun h -> R.valid r h
+
+(*
+ * Common postcondition for functions that return the
+ *   reprs for specific instance types
+ *)
+unfold let repr_post
+  (#b:R.slice)
+  (#a:Type) (#k:LP.parser_kind) (#p:LP.parser k a)
+  (r:repr b)  //input repr
+  (f:a -> HSM13.handshake13)  //one of the data-constructors for Parsers.Handshake13.handshake13
+  : HS.mem -> R.repr_p a b p -> HS.mem -> Type0
+  = fun h0 rr h1 ->
+    let open R in
+    B.(modifies loc_none h0 h1) /\
+    valid rr h1 /\  //the returned repr is valid in h1
+    value r == f (value rr) /\  //relation between the values of the two reprs
+    r.start_pos <= rr.start_pos /\  //slice indices for the instance repr are contained in the slice indices of r
+    r.end_pos == rr.end_pos
+
+let get_ee_repr (#b:R.slice) (r:repr b{is_ee r})
+  : Stack (EERepr.repr b)
+    (requires repr_pre r)
+    (ensures  repr_post r HSM13.M13_encrypted_extensions)
+  = R.reveal_valid ();
+    let ee_begin = HSM13.handshake13_accessor_encrypted_extensions b r.R.start_pos in
+
+    let h = ST.get () in
+    assume (v ee_begin + LP.content_length HSM13.handshake13_m13_encrypted_extensions_parser h b ee_begin == v r.R.end_pos);
+
+    R.mk b ee_begin r.R.end_pos HSM13.handshake13_m13_encrypted_extensions_parser
+
+let get_c_repr (#b:R.slice) (r:repr b{is_c r})
+  : Stack (CRepr.repr b)
+    (requires repr_pre r)
+    (ensures  repr_post r HSM13.M13_certificate)
+  = R.reveal_valid ();
+    let c_begin = HSM13.handshake13_accessor_certificate b r.R.start_pos in
+    
+    let h = ST.get () in
+    assume (v c_begin + LP.content_length HSM13.handshake13_m13_certificate_parser h b c_begin == v r.R.end_pos);
+    
+    R.mk b c_begin r.R.end_pos HSM13.handshake13_m13_certificate_parser
+
+let get_cv_repr (#b:R.slice) (r:repr b{is_cv r})
+  : Stack (CVRepr.repr b)
+    (requires repr_pre r)
+    (ensures  repr_post r HSM13.M13_certificate_verify)
+  = R.reveal_valid ();
+    let c_begin = HSM13.handshake13_accessor_certificate_verify b r.R.start_pos in
+    
+    let h = ST.get () in
+    assume (v c_begin + LP.content_length HSM13.handshake13_m13_certificate_verify_parser h b c_begin == v r.R.end_pos);
+    
+    R.mk b c_begin r.R.end_pos HSM13.handshake13_m13_certificate_verify_parser
+
+let get_fin_repr (#b:R.slice) (r:repr b{is_fin r})
+  : Stack (FinRepr.repr b)
+    (requires repr_pre r)
+    (ensures  repr_post r HSM13.M13_finished)
+  = R.reveal_valid ();
+    let f_begin = HSM13.handshake13_accessor_finished b r.R.start_pos in
+    
+    let h = ST.get () in
+    assume (v f_begin + LP.content_length HSM13.handshake13_m13_finished_parser h b f_begin == v r.R.end_pos);
+    
+    R.mk b f_begin r.R.end_pos HSM13.handshake13_m13_finished_parser

--- a/src/tls/MITLS.Repr.fst
+++ b/src/tls/MITLS.Repr.fst
@@ -90,7 +90,7 @@ type repr_meta (t:Type) = {
 noeq
 type repr (t:Type) (b:slice) = {
   start_pos: index b;
-  end_pos: i:index b {start_pos <= i };
+  end_pos: i:index b {start_pos <= i /\ i <= b.LP.len};
   meta: Ghost.erased (repr_meta t)
 }
 
@@ -189,7 +189,7 @@ let mk (b:slice) (from to:index b)
     (requires fun h ->
       LP.valid_pos parser h b from to)
     (ensures fun h0 r h1 ->
-      B.modifies B.loc_none h0 h1 /\
+      h0 == h1 /\
       valid r h1 /\
       r.start_pos = from /\
       r.end_pos = to /\

--- a/src/tls/MITLS.Repr.fst
+++ b/src/tls/MITLS.Repr.fst
@@ -55,7 +55,10 @@ let trivial_preorder : LP.srel LP.byte =
 /// A mutable slice: Eventually, we might just change this one
 ///   definition to be a const slice, multiplexing over mutable and
 ///   immutable LP.slices
-let slice = LP.slice trivial_preorder trivial_preorder
+let slice =
+  sl:LP.slice trivial_preorder trivial_preorder{
+    v sl.LP.len <= v LP.validator_max_length
+  }
 
 /// `index b` is the type of valid indexes into `b`
 let index (b:slice)= i:uint_32{ i <= LP.(b.len) }


### PR DESCRIPTION
This pull request contains a sample flight implementation in HSL using the reprs.

The flight implemented in the module is the `EE_C_CV_FIN` flight. In addition to adding repr modules for each of these flight types, I have also added a repr module for `Handshake13` messages (see https://github.com/project-everest/mitls-fstar/pull/225/files#diff-eb42ad423220e534651efcac13928b8c). This repr module provides predicates for specific instances (such as `is_ee`, `is_fin` etc.) and functions to obtain specific instance reprs (with corresponding predicates in the precondition), e.g. obtain a EE repr from an HSM13 repr, provides `is_ee` holds for the HSM13 repr.

The flight types in `HSL.Receive` are changed to return reprs, instead of indices and ghost messages separately. All the reprs are of type `MITLS.Repr.HSM13`, with refinements on their "kind" (`is_ee` etc.). There are additional refinements for stitching together the indices of multiple reprs in the same flight (see https://github.com/project-everest/mitls-fstar/pull/225/files#diff-52d8985a276b9061a526ee72c6b100a7R195).

The (ad-hoc) receive function returns this flight, with s (stateful) `valid` repr predicate for each of the reprs in the flight (see https://github.com/project-everest/mitls-fstar/pull/225/files#diff-52d8985a276b9061a526ee72c6b100a7R215).

Also some minor changes in `MITLS.Repr` here: https://github.com/project-everest/mitls-fstar/pull/225/files#diff-bb3be56c5c41c7d3146f3a6a947f1a4d.