### PR TITLE
Update memory model (see #227)

### DIFF
--- a/src/parsers/Parsers.rfc
+++ b/src/parsers/Parsers.rfc
@@ -1224,6 +1224,7 @@ struct {
 opaque SessionID<0..32>;
 
 enum /*@open*/ { nullCompression(0), (255) } CompressionMethod;
+enum { nullCompression(0), (255) } LegacyCompression;
 
 /** Shared Handshake Message Types **/
 
@@ -1232,17 +1233,31 @@ struct {
   Random random;
   SessionID session_id;
   CipherSuite cipher_suites<2..2^16-2>;
-  CompressionMethod compression_method<1..2^8-1>;
+  CompressionMethod compression_methods<1..2^8-1>;
   ClientHelloExtensions extensions;
 } ClientHello;
 
 struct {
-  ProtocolVersion version;
-  Random random;
   SessionID session_id;
   CipherSuite cipher_suite;
   CompressionMethod compression_method;
   ServerHelloExtensions extensions;
+} SHKind;
+
+struct {
+  SessionID session_id;
+  CipherSuite cipher_suite;
+  LegacyCompression legacy_compression;
+  HRRExtensions extensions;
+} HRRKind;
+
+struct {
+  ProtocolVersion version;
+  opaque random[32];
+  (if random = "CF21AD74E59A6111BE1D8C021E65B891C2A211167ABB8C5E079E09E2C8A8339C"
+    HRRKind
+  else
+    SHKind) is_hrr;
 } ServerHello;
 
 /** TLS 1.3 Handshake Messages */

--- a/src/parsers/Parsers.rfc
+++ b/src/parsers/Parsers.rfc
@@ -1251,6 +1251,15 @@ struct {
   HRRExtensions extensions;
 } HRRKind;
 
+/*
+We need to change the definition of the ServerHello
+type to account for the syntactic differences between
+ServerHello and HelloRetryRequest.
+
+In a HRR, the compression_method must be null and the
+format of some extensions is different (e.g. key_share
+is a KeyShareEntry in SH and a GroupName in HRR)
+*/
 struct {
   ProtocolVersion version;
   opaque random[32];
@@ -1259,6 +1268,27 @@ struct {
   else
     SHKind) is_hrr;
 } ServerHello;
+
+/*
+Using an if-then-else type is annoying, in the specification
+of the handshake we want to convert it to either SH or HRR.
+*/
+struct {
+  ProtocolVersion version;
+  Random random;
+  SessionID session_id;
+  CipherSuite cipher_suite;
+  CompressionMethod compression_method;
+  ServerHelloExtensions extensions;
+} RealServerHello;
+
+struct {
+  ProtocolVersion version;
+  SessionID session_id;
+  CipherSuite cipher_suite;
+  LegacyCompression legacy_compression;
+  HRRExtensions extensions;
+} HelloRetryRequest;
 
 /** TLS 1.3 Handshake Messages */
 

--- a/src/tls/DHGroup.fst
+++ b/src/tls/DHGroup.fst
@@ -213,9 +213,9 @@ let dhparam_serializer: LP.serializer dhparam_parser =
   LP.serialize_synth
     _ 
     synth_dhparams
-    (LP.serialize_nondep_then _ vls () _
-      (LP.serialize_nondep_then _ vls () _
-        (LP.serialize_nondep_then _ vls () _ vls)))
+    (LP.serialize_nondep_then vls
+      (LP.serialize_nondep_then vls
+        (LP.serialize_nondep_then vls vls)))
     unsynth_dhparams
     ()
 
@@ -227,11 +227,11 @@ let dhparam_serializer32: LP.serializer32 dhparam_serializer =
     _
     synth_dhparams
     _
-    (LP.serialize32_nondep_then vls32 ()
-      (LP.serialize32_nondep_then vls32 ()
-        (LP.serialize32_nondep_then vls32 () vls32 ())
-      ())
-    ())
+    (LP.serialize32_nondep_then vls32
+      (LP.serialize32_nondep_then vls32
+        (LP.serialize32_nondep_then vls32 vls32)
+      )
+    )
     unsynth_dhparams
     (fun x -> unsynth_dhparams x)
     ()

--- a/src/tls/DefineTable.fst
+++ b/src/tls/DefineTable.fst
@@ -1,0 +1,108 @@
+module DefineTable
+
+open Mem
+
+module M = LowStar.Modifies
+module DM = FStar.DependentMap
+module MH = FStar.Monotonic.Heap
+module HS = FStar.HyperStack
+
+friend FStar.Monotonic.DependentMap
+
+let dt_forall #it #vt t pred h =
+  model ==> (forall (i:it) (k:vt i).
+  {:pattern (defined_as t i k h)}
+  defined_as t i k h ==> pred i k h)
+
+let lemma_forall_empty #it #vt t pred h = ()
+
+let lemma_forall_elim #it #vt t pred i k h = ()
+
+val lemma_forall_extend_wit:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: MDM.map it vt ->
+  t': MDM.map it vt ->
+  pred: (i:it -> vt i -> mem -> GTot Type0) ->
+  i: it -> k: vt i ->
+  h: mem ->
+  x:it -> y:vt x ->
+  Lemma
+    (requires model /\ pred i k h /\
+      ((MDM.sel t x == Some y) ==> pred x y h) /\
+      t' == (| i, k |) :: t)
+    (ensures (MDM.sel t' x == Some y) ==> pred x y h)
+
+let lemma_forall_extend_wit #it #vt t t' pred i k h x y = ()
+
+let lemma_forall_extend #it #vt t pred pred_frame i k h0 h1 =
+  if model then
+    let t0 = HS.sel h0 (ideal t) in
+    let t1 = HS.sel h1 (ideal t) in
+    let pred_frame' (i:it) (k:vt i) (h0:mem) (h1:mem)
+      : Lemma ((pred i k h0 /\ M.modifies (loc t) h0 h1) ==> pred i k h1) =
+      FStar.Classical.move_requires (pred_frame i k h0) h1
+      in
+    let lupd (x:it) (y:vt x) : Lemma
+      (requires (MDM.sel t0 x == Some y) ==> pred x y h0)
+      (ensures (MDM.sel t1 x == Some y) ==> pred x y h1) =
+      assert(MDM.sel t1 x == (if x = i then Some k else MDM.sel t0 x));
+      if x = i then ()
+      else pred_frame' x y h0 h1
+      in
+    let prove_on_witness (x:it) (y:vt x)
+      : Lemma (MDM.sel t1 x == Some y ==> pred x y h1)
+      =
+      lemma_forall_elim t pred x y h0;
+      lupd x y;
+      lemma_forall_extend_wit t0 t1 pred i k h1 x y in
+    FStar.Classical.forall_intro_2 prove_on_witness
+  else ()
+
+val lemma_forall_frame_wit:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  pred: (i:it -> vt i -> mem -> GTot Type0) ->
+  pred_fp: M.loc ->
+  pred_frame: (i:it -> k:vt i -> h0:mem -> l:M.loc -> h1:mem -> Lemma
+    ((pred i k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l pred_fp)
+     ==> pred i k h1)) ->
+  h0: mem -> l:M.loc -> h1: mem ->
+  x:it -> y:vt x ->
+  Lemma
+    (requires M.modifies l h0 h1 /\ t `used_in` h0 /\
+      (defined_as t x y h0 ==> pred x y h0) /\
+      M.loc_disjoint (loc t) l /\ M.loc_disjoint pred_fp l)
+    (ensures defined_as t x y h1 ==> pred x y h1)
+
+let lemma_forall_frame_wit #it #vt t pred pred_fp pred_frame h0 l h1 x y =
+  lemma_frame_dt t h0 l h1;
+  pred_frame x y h0 l h1
+
+let lemma_forall_frame #it #vt t pred pred_fp pred_frame h0 l h1 =
+  if model then 
+    let pred_frame' (i:it) (k:vt i) (h0:mem) (l:M.loc) (h1:mem)
+      : Lemma ((pred i k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l pred_fp)
+         ==> pred i k h1) =
+      FStar.Classical.move_requires (pred_frame i k h0 l) h1
+      in
+    let prove_on_witness (x:it) (y:vt x)
+      : Lemma (defined_as t x y h1 ==> pred x y h1)
+      =
+      lemma_forall_elim t pred x y h0;
+      lemma_forall_frame_wit t pred pred_fp pred_frame' h0 l h1 x y in
+    FStar.Classical.forall_intro_2 prove_on_witness
+  else ()
+
+val fold_gtot: ('a -> 'b -> GTot 'a) -> 'a -> l:list 'b -> GTot 'a (decreases l)
+let rec fold_gtot f x l = match l with
+  | [] -> x
+  | hd::tl -> fold_gtot f (f x hd) tl
+
+let footprint #it #vt t fp h =
+  if model then 
+    let l = HS.sel h (ideal t) in
+    fold_gtot (fun l (| i, k |) -> M.loc_union l (fp i k)) M.loc_none l
+  else M.loc_none
+

--- a/src/tls/DefineTable.fst
+++ b/src/tls/DefineTable.fst
@@ -16,7 +16,7 @@ let alloc #it vt =
     MDM.alloc #it #vt #(fun _ -> True) #tls_define_region ()
   else ()
 
-let extend #it #vt t i k =
+let extend #it #vt t #i k =
   if model then
    begin
     let t0 = ideal t in
@@ -27,32 +27,33 @@ let extend #it #vt t i k =
   else ()
 
 let dt_forall #it #vt t pred h =
-  model ==> (forall (i:it) (k:vt i).
-  {:pattern (defined_as t i k h)}
-  defined_as t i k h ==> pred k h)
+  model ==> (forall (i:it) (k:vt i{defined_as t k h}).
+  {:pattern (defined_as t k h)} pred k h)
 
 val fold_gtot: ('a -> 'b -> GTot 'a) -> 'a -> l:list 'b -> GTot 'a (decreases l)
 let rec fold_gtot f x l = match l with
   | [] -> x
   | hd::tl -> f (fold_gtot f x tl) hd
 
-let fp_add (#it:eqtype) (#vt:it->Type) (#p:M.loc) (fp:local_fp vt p)
-  (l:sub_loc p) (cur:(i:it & vt i)) : GTot (sub_loc p) =
+let fp_add (#it:eqtype) (#vt:it->Type)
+  (fp:local_fp vt) (l:M.loc) (cur:(i:it & vt i)) =
   let (| i, k |) = cur in
   M.loc_union l (fp k)
 
-let footprint #it #vt t #parent fp h =
+let footprint #it #vt t fp h =
   if model then 
     let l = HS.sel h (ideal t) in
     fold_gtot (fp_add fp) M.loc_none l
   else M.loc_none
 
-let lemma_footprint_frame #it #vt t #p fp h0 h1 = ()
+let lemma_footprint_empty #it #vt t fp h0 = ()
 
-let lemma_footprint_extend #it #vt t #p fp i k h0 h1 = ()
+let lemma_footprint_frame #it #vt t fp h0 h1 = ()
+
+let lemma_footprint_extend #it #vt t fp #i k h0 h1 = ()
 
 let rec lemma_fp_includes (#it:eqtype) (vt:it->Type) (t:MDM.map it vt)
-  (#p:M.loc) (fp:local_fp vt p) (i:it) (k:vt i)
+  (fp:local_fp vt) (#i:it) (k:vt i)
   : Lemma (requires (MDM.sel t i == Some k))
   (ensures fold_gtot (fp_add fp) M.loc_none t `M.loc_includes` (fp k))
   (decreases %[t])
@@ -61,104 +62,39 @@ let rec lemma_fp_includes (#it:eqtype) (vt:it->Type) (t:MDM.map it vt)
   | [] -> ()
   | (| x, y |) :: tl ->
     if x = i then ()
-    else lemma_fp_includes vt tl fp i k
+    else lemma_fp_includes vt tl fp k
 
-let lemma_footprint_includes #it #vt t #p fp i k h =
+let lemma_footprint_includes #it #vt t fp #i k h =
   if model then
     let t0 = HS.sel h (ideal t) in
-    lemma_fp_includes vt t0 fp i k
+    lemma_fp_includes vt t0 fp k
   else ()
 
 let lemma_forall_empty #it #vt t pred h = ()
 
-let lemma_forall_elim #it #vt t pred i k h = ()
+let lemma_forall_elim #it #vt t pred h #i k = ()
 
-val lemma_forall_extend_wit:
-  #it: eqtype ->
-  #vt: (it -> Type) ->
-  t: MDM.map it vt ->
-  t': MDM.map it vt ->
-  pred: (#i:it -> vt i -> mem -> GTot Type0) ->
-  #i: it -> k: vt i ->
-  h: mem ->
-  x:it -> y:vt x ->
-  Lemma
-    (requires model /\ pred k h /\
-      ((MDM.sel t x == Some y) ==> pred #x y h) /\
-      t' == (| i, k |) :: t)
-    (ensures (MDM.sel t' x == Some y) ==> pred #x y h)
-
-let lemma_forall_extend_wit #it #vt t t' pred #i k h x y = ()
-
-let lemma_forall_extend #it #vt t pred #p fp pred_frame #i k h0 h1 =
+let lemma_forall_extend #it #vt t pred fp pred_frame #i k h0 h1 =
   if model then
-    let t0 = HS.sel h0 (ideal t) in
-    let t1 = HS.sel h1 (ideal t) in
-    let pred_frame' (#i:it) (k:vt i) (h0:mem) (l:M.loc) (h1:mem)
-      : Lemma ((pred k h0 /\ M.modifies l h0 h1 /\
-        M.loc_disjoint l (fp k)) ==> pred k h1) =
-      FStar.Classical.move_requires (pred_frame k h0 l) h1
-      in
-    let lupd (#x:it) (y:vt x) : Lemma
-      (requires (MDM.sel t0 x == Some y) ==> pred #x y h0)
-      (ensures (MDM.sel t1 x == Some y) ==> pred #x y h1) =
-      assert(MDM.sel t1 x == (if x = i then Some k else MDM.sel t0 x));
+    let prove_on_witness (x:it) (y:vt x{defined_as t y h1})
+      : Lemma (pred y h1) =
       if x = i then ()
-      else pred_frame' #x y h0 (loc t) h1
-      in
-    let prove_on_witness (x:it) (y:vt x)
-      : Lemma (MDM.sel t1 x == Some y ==> pred #x y h1)
-      =
-      lemma_forall_elim t pred x y h0;
-      lupd #x y;
-      lemma_forall_extend_wit t0 t1 pred #i k h1 x y
-      in
+      else (
+        lemma_forall_elim t pred h0 y;
+        lemma_footprint_includes t fp y h0;
+        pred_frame y h0 (loc t) h1
+      ) in
     FStar.Classical.forall_intro_2 prove_on_witness
   else ()
 
-val lemma_forall_frame_wit:
-  #it: eqtype ->
-  #vt: (it -> Type) ->
-  t: dt vt ->
-  pred: (#i:it -> vt i -> mem -> GTot Type0) ->
-  #parent: M.loc ->
-  fp: local_fp vt parent ->
-  pred_frame: (#i:it -> k:vt i -> h0:mem -> l:M.loc -> h1:mem -> Lemma
-    ((pred k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l (fp k))
-     ==> pred k h1)) ->
-  h0: mem -> l:M.loc -> h1: mem ->
-  x:it -> y:vt x ->
-  Lemma
-    (requires M.modifies l h0 h1 /\ t `live` h0 /\
-      (defined_as t x y h0 ==> pred y h0) /\
-      M.loc_disjoint l (loc t) /\ M.loc_disjoint l (fp y))
-    (ensures defined_as t x y h1 ==> pred y h1)
-
-let lemma_forall_frame_wit #it #vt t pred #p fp pred_frame h0 l h1 x y =
-  lemma_unchanged_frame t h0 l h1;
-  pred_frame y h0 l h1
-
-// Could be simplified if FStar.Classical had
-// move_requires_2 or forall_impl_intro_2
-let lemma_forall_frame #it #vt t pred #p fp pred_frame h0 l h1 =
+let lemma_forall_frame #it #vt t pred fp pred_frame h0 l h1 =
   if model then 
-    let pred_frame' (#i:it) (k:vt i) (h0:mem) (l:M.loc) (h1:mem)
-      : Lemma ((pred k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l (fp k))
-         ==> pred k h1) =
-      FStar.Classical.move_requires (pred_frame k h0 l) h1
-      in
-    let prove_on_witness (v:(i:it & vt i))
-      : Lemma (requires defined_as t (dfst v) (dsnd v) h1)
-        (ensures pred (dsnd v) h1)
+    let prove_on_witness (x:it) (y:vt x{defined_as t y h1})
+      : Lemma (ensures pred y h1)
       =
-      let (| x, y |) = v in
-      lemma_forall_elim t pred x y h0;
-      lemma_footprint_includes t fp x y h0;
-      lemma_forall_frame_wit t pred fp pred_frame' h0 l h1 x y
+      lemma_forall_elim t pred h0 y;
+      lemma_footprint_includes t fp y h0;
+      pred_frame y h0 l h1
       in
-    let prove_on_witness2 (x:it) (y:vt x)
-      : Lemma (defined_as t x y h1 ==> pred y h1)
-      = FStar.Classical.move_requires prove_on_witness (|x,y|)
-      in
-    FStar.Classical.forall_intro_2 prove_on_witness2
+    FStar.Classical.forall_intro_2 prove_on_witness
   else ()

--- a/src/tls/DefineTable.fst
+++ b/src/tls/DefineTable.fst
@@ -7,12 +7,67 @@ module DM = FStar.DependentMap
 module MH = FStar.Monotonic.Heap
 module HS = FStar.HyperStack
 
+open FStar.HyperStack.ST
+
 friend FStar.Monotonic.DependentMap
+
+let alloc #it vt =
+  if model then
+    MDM.alloc #it #vt #(fun _ -> True) #tls_define_region ()
+  else ()
+
+let extend #it #vt t i k =
+  if model then
+   begin
+    let t0 = ideal t in
+    recall t0;
+    t0 := MDM.upd !t0 i k;
+    mr_witness t0 (MDM.contains t0 i k)
+   end
+  else ()
 
 let dt_forall #it #vt t pred h =
   model ==> (forall (i:it) (k:vt i).
   {:pattern (defined_as t i k h)}
-  defined_as t i k h ==> pred i k h)
+  defined_as t i k h ==> pred k h)
+
+val fold_gtot: ('a -> 'b -> GTot 'a) -> 'a -> l:list 'b -> GTot 'a (decreases l)
+let rec fold_gtot f x l = match l with
+  | [] -> x
+  | hd::tl -> f (fold_gtot f x tl) hd
+
+let fp_add (#it:eqtype) (#vt:it->Type) (#p:M.loc) (fp:local_fp vt p)
+  (l:sub_loc p) (cur:(i:it & vt i)) : GTot (sub_loc p) =
+  let (| i, k |) = cur in
+  M.loc_union l (fp k)
+
+let footprint #it #vt t #parent fp h =
+  if model then 
+    let l = HS.sel h (ideal t) in
+    fold_gtot (fp_add fp) M.loc_none l
+  else M.loc_none
+
+let lemma_footprint_frame #it #vt t #p fp h0 h1 = ()
+
+let lemma_footprint_extend #it #vt t #p fp i k h0 h1 = ()
+
+let rec lemma_fp_includes (#it:eqtype) (vt:it->Type) (t:MDM.map it vt)
+  (#p:M.loc) (fp:local_fp vt p) (i:it) (k:vt i)
+  : Lemma (requires (MDM.sel t i == Some k))
+  (ensures fold_gtot (fp_add fp) M.loc_none t `M.loc_includes` (fp k))
+  (decreases %[t])
+  =
+  match t with
+  | [] -> ()
+  | (| x, y |) :: tl ->
+    if x = i then ()
+    else lemma_fp_includes vt tl fp i k
+
+let lemma_footprint_includes #it #vt t #p fp i k h =
+  if model then
+    let t0 = HS.sel h (ideal t) in
+    lemma_fp_includes vt t0 fp i k
+  else ()
 
 let lemma_forall_empty #it #vt t pred h = ()
 
@@ -23,39 +78,41 @@ val lemma_forall_extend_wit:
   #vt: (it -> Type) ->
   t: MDM.map it vt ->
   t': MDM.map it vt ->
-  pred: (i:it -> vt i -> mem -> GTot Type0) ->
-  i: it -> k: vt i ->
+  pred: (#i:it -> vt i -> mem -> GTot Type0) ->
+  #i: it -> k: vt i ->
   h: mem ->
   x:it -> y:vt x ->
   Lemma
-    (requires model /\ pred i k h /\
-      ((MDM.sel t x == Some y) ==> pred x y h) /\
+    (requires model /\ pred k h /\
+      ((MDM.sel t x == Some y) ==> pred #x y h) /\
       t' == (| i, k |) :: t)
-    (ensures (MDM.sel t' x == Some y) ==> pred x y h)
+    (ensures (MDM.sel t' x == Some y) ==> pred #x y h)
 
-let lemma_forall_extend_wit #it #vt t t' pred i k h x y = ()
+let lemma_forall_extend_wit #it #vt t t' pred #i k h x y = ()
 
-let lemma_forall_extend #it #vt t pred pred_frame i k h0 h1 =
+let lemma_forall_extend #it #vt t pred #p fp pred_frame #i k h0 h1 =
   if model then
     let t0 = HS.sel h0 (ideal t) in
     let t1 = HS.sel h1 (ideal t) in
-    let pred_frame' (i:it) (k:vt i) (h0:mem) (h1:mem)
-      : Lemma ((pred i k h0 /\ M.modifies (loc t) h0 h1) ==> pred i k h1) =
-      FStar.Classical.move_requires (pred_frame i k h0) h1
+    let pred_frame' (#i:it) (k:vt i) (h0:mem) (l:M.loc) (h1:mem)
+      : Lemma ((pred k h0 /\ M.modifies l h0 h1 /\
+        M.loc_disjoint l (fp k)) ==> pred k h1) =
+      FStar.Classical.move_requires (pred_frame k h0 l) h1
       in
-    let lupd (x:it) (y:vt x) : Lemma
-      (requires (MDM.sel t0 x == Some y) ==> pred x y h0)
-      (ensures (MDM.sel t1 x == Some y) ==> pred x y h1) =
+    let lupd (#x:it) (y:vt x) : Lemma
+      (requires (MDM.sel t0 x == Some y) ==> pred #x y h0)
+      (ensures (MDM.sel t1 x == Some y) ==> pred #x y h1) =
       assert(MDM.sel t1 x == (if x = i then Some k else MDM.sel t0 x));
       if x = i then ()
-      else pred_frame' x y h0 h1
+      else pred_frame' #x y h0 (loc t) h1
       in
     let prove_on_witness (x:it) (y:vt x)
-      : Lemma (MDM.sel t1 x == Some y ==> pred x y h1)
+      : Lemma (MDM.sel t1 x == Some y ==> pred #x y h1)
       =
       lemma_forall_elim t pred x y h0;
-      lupd x y;
-      lemma_forall_extend_wit t0 t1 pred i k h1 x y in
+      lupd #x y;
+      lemma_forall_extend_wit t0 t1 pred #i k h1 x y
+      in
     FStar.Classical.forall_intro_2 prove_on_witness
   else ()
 
@@ -63,46 +120,45 @@ val lemma_forall_frame_wit:
   #it: eqtype ->
   #vt: (it -> Type) ->
   t: dt vt ->
-  pred: (i:it -> vt i -> mem -> GTot Type0) ->
-  pred_fp: M.loc ->
-  pred_frame: (i:it -> k:vt i -> h0:mem -> l:M.loc -> h1:mem -> Lemma
-    ((pred i k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l pred_fp)
-     ==> pred i k h1)) ->
+  pred: (#i:it -> vt i -> mem -> GTot Type0) ->
+  #parent: M.loc ->
+  fp: local_fp vt parent ->
+  pred_frame: (#i:it -> k:vt i -> h0:mem -> l:M.loc -> h1:mem -> Lemma
+    ((pred k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l (fp k))
+     ==> pred k h1)) ->
   h0: mem -> l:M.loc -> h1: mem ->
   x:it -> y:vt x ->
   Lemma
-    (requires M.modifies l h0 h1 /\ t `used_in` h0 /\
-      (defined_as t x y h0 ==> pred x y h0) /\
-      M.loc_disjoint (loc t) l /\ M.loc_disjoint pred_fp l)
-    (ensures defined_as t x y h1 ==> pred x y h1)
+    (requires M.modifies l h0 h1 /\ t `live` h0 /\
+      (defined_as t x y h0 ==> pred y h0) /\
+      M.loc_disjoint l (loc t) /\ M.loc_disjoint l (fp y))
+    (ensures defined_as t x y h1 ==> pred y h1)
 
-let lemma_forall_frame_wit #it #vt t pred pred_fp pred_frame h0 l h1 x y =
-  lemma_frame_dt t h0 l h1;
-  pred_frame x y h0 l h1
+let lemma_forall_frame_wit #it #vt t pred #p fp pred_frame h0 l h1 x y =
+  lemma_unchanged_frame t h0 l h1;
+  pred_frame y h0 l h1
 
-let lemma_forall_frame #it #vt t pred pred_fp pred_frame h0 l h1 =
+// Could be simplified if FStar.Classical had
+// move_requires_2 or forall_impl_intro_2
+let lemma_forall_frame #it #vt t pred #p fp pred_frame h0 l h1 =
   if model then 
-    let pred_frame' (i:it) (k:vt i) (h0:mem) (l:M.loc) (h1:mem)
-      : Lemma ((pred i k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l pred_fp)
-         ==> pred i k h1) =
-      FStar.Classical.move_requires (pred_frame i k h0 l) h1
+    let pred_frame' (#i:it) (k:vt i) (h0:mem) (l:M.loc) (h1:mem)
+      : Lemma ((pred k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l (fp k))
+         ==> pred k h1) =
+      FStar.Classical.move_requires (pred_frame k h0 l) h1
       in
-    let prove_on_witness (x:it) (y:vt x)
-      : Lemma (defined_as t x y h1 ==> pred x y h1)
+    let prove_on_witness (v:(i:it & vt i))
+      : Lemma (requires defined_as t (dfst v) (dsnd v) h1)
+        (ensures pred (dsnd v) h1)
       =
+      let (| x, y |) = v in
       lemma_forall_elim t pred x y h0;
-      lemma_forall_frame_wit t pred pred_fp pred_frame' h0 l h1 x y in
-    FStar.Classical.forall_intro_2 prove_on_witness
+      lemma_footprint_includes t fp x y h0;
+      lemma_forall_frame_wit t pred fp pred_frame' h0 l h1 x y
+      in
+    let prove_on_witness2 (x:it) (y:vt x)
+      : Lemma (defined_as t x y h1 ==> pred y h1)
+      = FStar.Classical.move_requires prove_on_witness (|x,y|)
+      in
+    FStar.Classical.forall_intro_2 prove_on_witness2
   else ()
-
-val fold_gtot: ('a -> 'b -> GTot 'a) -> 'a -> l:list 'b -> GTot 'a (decreases l)
-let rec fold_gtot f x l = match l with
-  | [] -> x
-  | hd::tl -> fold_gtot f (f x hd) tl
-
-let footprint #it #vt t fp h =
-  if model then 
-    let l = HS.sel h (ideal t) in
-    fold_gtot (fun l (| i, k |) -> M.loc_union l (fp i k)) M.loc_none l
-  else M.loc_none
-

--- a/src/tls/DefineTable.fst
+++ b/src/tls/DefineTable.fst
@@ -96,6 +96,8 @@ let lemma_forall_empty #it #vt t pred h = ()
 
 let lemma_forall_elim #it #vt t pred h #i k = ()
 
+let lemma_forall_restore #it #vt t pred fp #i k h0 h1 = admit ()
+
 let lemma_forall_extend #it #vt t pred fp pred_frame #i k h0 h1 =
   if model then
     let prove_on_witness (x:it) (y:vt x{defined_as t y h1})

--- a/src/tls/DefineTable.fst
+++ b/src/tls/DefineTable.fst
@@ -96,8 +96,6 @@ let lemma_forall_empty #it #vt t pred h = ()
 
 let lemma_forall_elim #it #vt t pred h #i k = ()
 
-let lemma_forall_restore #it #vt t pred fp #i k h0 h1 = admit ()
-
 let lemma_forall_extend #it #vt t pred fp pred_frame #i k h0 h1 =
   if model then
     let prove_on_witness (x:it) (y:vt x{defined_as t y h1})
@@ -110,6 +108,8 @@ let lemma_forall_extend #it #vt t pred fp pred_frame #i k h0 h1 =
       ) in
     FStar.Classical.forall_intro_2 prove_on_witness
   else ()
+
+let lemma_forall_restore #it #vt t pred fp pred_frame #i k h0 h1 = admit ()
 
 let lemma_forall_frame #it #vt t pred fp pred_frame h0 l h1 =
   if model then 

--- a/src/tls/DefineTable.fst
+++ b/src/tls/DefineTable.fst
@@ -43,6 +43,8 @@ let fp_add (#it:eqtype) (#vt:it->Type)
 let empty_fp #it vt =
   fun (#i:it) (k:vt i) -> M.loc_none
 
+let lemma_empty_fp_none #it #vt #i k = ()
+
 let rec lemma_fold_constant (#it:eqtype) (#vt:it->Type)
   (f: M.loc -> (i:it & vt i) -> GTot M.loc)
   (x0:M.loc) (l: list (i:it & vt i))

--- a/src/tls/DefineTable.fst
+++ b/src/tls/DefineTable.fst
@@ -40,11 +40,31 @@ let fp_add (#it:eqtype) (#vt:it->Type)
   let (| i, k |) = cur in
   M.loc_union l (fp k)
 
+let empty_fp #it vt =
+  fun (#i:it) (k:vt i) -> M.loc_none
+
+let rec lemma_fold_constant (#it:eqtype) (#vt:it->Type)
+  (f: M.loc -> (i:it & vt i) -> GTot M.loc)
+  (x0:M.loc) (l: list (i:it & vt i))
+  : Lemma
+    (requires (forall (x:M.loc) (y:(i:it & vt i)). f x y == x))
+    (ensures fold_gtot f x0 l == x0)
+  =
+  match l with
+  | [] -> ()
+  | h :: t -> lemma_fold_constant f x0 t
+
 let footprint #it #vt t fp h =
   if model then 
     let l = HS.sel h (ideal t) in
     fold_gtot (fp_add fp) M.loc_none l
   else M.loc_none
+
+let lemma_footprint_empty_fp #it #vt t h =
+  if model then
+    let l = HS.sel h (ideal t) in
+    lemma_fold_constant (fp_add (empty_fp vt)) M.loc_none l
+  else ()
 
 let lemma_footprint_empty #it #vt t fp h0 = ()
 

--- a/src/tls/DefineTable.fsti
+++ b/src/tls/DefineTable.fsti
@@ -32,11 +32,23 @@ inline_for_extraction type dt (#it:eqtype) (vt:it->Type) =
 let ideal (#it:eqtype) (#vt:it->Type) (t:dt vt) : Pure (table vt)
   (requires model) (ensures fun _ -> True) = t
 
+let real (#it:eqtype) (#vt:it->Type) (t:dt vt) : Pure unit
+  (requires not model) (ensures fun _ -> True) = t
+
 let loc (#it:eqtype) (#vt:it->Type) (t:dt vt) =
-  if model then M.loc_mreference (ideal t) else M.loc_none
+  (if model then M.loc_mreference (ideal t) else M.loc_none)
+
+type live (#it:eqtype) (#vt:it -> Type) (t:dt vt) (h:mem) =
+  (model ==> h `HS.contains` (ideal t))
 
 type fresh (#it:eqtype) (#vt:it -> Type) (t:dt vt) (i:it) (h:mem) =
-  model ==> MDM.fresh (ideal t) i h
+  (model ==> MDM.fresh (ideal t) i h)
+
+let lemma_fresh_frame (#it:eqtype) (#vt:it -> Type) (t:dt vt) (i:it)
+  (h0:mem) (l:M.loc) (h1:mem) : Lemma
+  (requires fresh t i h0 /\ M.modifies l h0 h1 /\
+    M.loc_disjoint l (loc t) /\ live t h0)
+  (ensures fresh t i h1) = ()
 
 type defined_as (#it:eqtype) (#vt:it -> Type) (t:dt vt) (i:it) (k:vt i) (h:mem) =
   model ==> (MDM.sel (HS.sel h (ideal t)) i == Some k)
@@ -56,6 +68,11 @@ type extended (#it:eqtype) (#vt:it -> Type) (t:dt vt)
 type unchanged (#it:eqtype) (#vt:it -> Type) (t:dt vt) (h0 h1:mem) =
   model ==> HS.sel h0 (ideal t) == HS.sel h1 (ideal t)
 
+let lemma_unchanged_frame (#it:eqtype) (#vt:it -> Type) (t:dt vt)
+  (h0:mem) (l:M.loc) (h1:mem) : Lemma
+  (requires M.modifies l h0 h1 /\ live t h0 /\ M.loc_disjoint l (loc t))
+  (ensures unchanged t h0 h1) = ()
+
 type empty (#it:eqtype) (#vt:it -> Type) (t:dt vt) (h1:mem) =
   model ==> HS.sel h1 (ideal t) == MDM.empty
 
@@ -63,26 +80,29 @@ type disjoint (#it:eqtype) (#vt:it -> Type) (t:dt vt)
   (#it':eqtype) (#vt':it' -> Type) (t':dt vt') =
   M.loc_disjoint (loc t) (loc t')
 
-let alloc (#it:eqtype) (vt:it -> Type) : ST (dt vt)
-  (requires fun h0 -> True)
-  (ensures fun h0 t h1 -> M.modifies (loc t) h0 h1 /\ empty t h1)
-  =
-  if model then (MDM.alloc #it #vt #(fun _ -> True) #tls_define_region ())
-  else ()
-
-type used_in (#it:eqtype) (#vt:it -> Type) (t:dt vt) (h:mem) =
-  model ==> h `HS.contains` (ideal t)
-
 let lemma_disjoint_unchanged (#it:eqtype) (#vt:it -> Type) (t:dt vt)
   (#it':eqtype) (#vt':it' -> Type) (t':dt vt') (h0:mem) (h1:mem) : Lemma
-  (requires M.modifies (loc t) h0 h1 /\
-    disjoint t t' /\ used_in t h0 /\ used_in t' h0)
+  (requires M.modifies (loc t) h0 h1 /\ disjoint t t' /\
+    live t h0 /\ live t' h0)
   (ensures unchanged t' h0 h1) = ()
 
-let lemma_frame_dt (#it:eqtype) (#vt:it -> Type) (t:dt vt)
-  (h0:mem) (l:M.loc) (h1:mem) : Lemma
-  (requires M.modifies l h0 h1 /\ used_in t h0 /\ M.loc_disjoint l (loc t))
-  (ensures unchanged t h0 h1) = ()
+val alloc:
+  #it:eqtype ->
+  vt: (it -> Type) ->
+  ST (dt vt)
+  (requires fun h0 -> True)
+  (ensures fun h0 t h1 -> M.modifies M.loc_none h0 h1 /\
+    empty t h1 /\ fresh_loc (loc t) h0 h1)
+
+val extend:
+  #it:eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  i: it ->
+  k: vt i ->
+  ST unit
+  (requires fun h0 -> fresh t i h0)
+  (ensures fun h0 () h1 -> extended t i k h0 h1)
 
 (* Used to define a joint invariant over all defined instances
 The definition is opaque but the lemmas below are enough to use
@@ -91,15 +111,67 @@ val dt_forall:
   #it: eqtype ->
   #vt: (it -> Type) ->
   t: dt vt ->
-  pred: (i:it -> vt i -> mem -> GTot Type0) ->
+  pred: (#i:it -> vt i -> mem -> GTot Type0) ->
   h: mem ->
   Type0
+
+type local_fp (#it:eqtype) (vt:it->Type) (parent:M.loc) =
+  #i:it -> vt i -> sub_loc parent
+
+// Package footprint = union of all instance footprints
+val footprint:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  #parent: M.loc ->
+  fp: local_fp vt parent ->
+  h: mem ->
+  GTot (sub_loc parent)
+
+val lemma_footprint_frame:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  #parent: M.loc ->
+  fp: local_fp vt parent ->
+  h0: mem ->
+  h1: mem ->
+  Lemma
+    (requires unchanged t h0 h1)
+    (ensures footprint t fp h0 == footprint t fp h1)
+
+val lemma_footprint_extend: 
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  #parent: M.loc ->
+  fp: local_fp vt parent ->
+  i: it ->
+  k: vt i ->
+  h0: mem ->
+  h1: mem ->
+  Lemma
+    (requires extended t i k h0 h1)
+    (ensures footprint t fp h1 == M.loc_union (footprint t fp h0) (fp k))
+
+val lemma_footprint_includes:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  #parent: M.loc ->
+  fp: local_fp vt parent ->
+  i: it ->
+  k: vt i ->
+  h: mem ->
+  Lemma
+    (requires defined_as t i k h)
+    (ensures (footprint t fp h) `M.loc_includes` (fp k))
 
 val lemma_forall_empty:
   #it: eqtype ->
   #vt: (it -> Type) ->
   t: dt vt ->
-  pred: (i:it -> vt i -> mem -> GTot Type0) ->
+  pred: (#i:it -> vt i -> mem -> GTot Type0) ->
   h: mem ->
   Lemma 
     (requires empty t h)
@@ -109,77 +181,48 @@ val lemma_forall_elim:
   #it: eqtype ->
   #vt: (it -> Type) ->
   t: dt vt ->
-  pred: (i:it -> vt i -> mem -> GTot Type0) ->
+  pred: (#i:it -> vt i -> mem -> GTot Type0) ->
   i: it -> k: vt i ->
   h: mem ->
   Lemma
     (requires dt_forall t pred h /\ model)
-    (ensures defined_as t i k h ==> pred i k h)
+    (ensures defined_as t i k h ==> pred k h)
 
 val lemma_forall_extend:
   #it: eqtype ->
   #vt: (it -> Type) ->
   t: dt vt ->
-  pred: (i:it -> vt i -> mem -> GTot Type0) ->
-  pred_frame: (i:it -> k:vt i -> h0:mem -> h1:mem -> Lemma
-    (requires pred i k h0 /\ M.modifies (loc t) h0 h1)
-    (ensures pred i k h1)) ->
-  i: it -> k: vt i ->
+  pred: (#i:it -> vt i -> mem -> GTot Type0) ->
+  #parent: M.loc ->
+  fp: local_fp vt parent ->
+  pred_frame: (#i:it -> k:vt i -> h0:mem -> l:M.loc -> h1:mem -> Lemma
+    (requires pred k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l (fp k))
+    (ensures pred k h1)) ->
+  #i: it -> k: vt i ->
   h0: mem -> h1: mem ->
   Lemma
-    (requires dt_forall t pred h0 /\
-      extended t i k h0 h1 /\ pred i k h1)
+    (requires dt_forall t pred h0 /\ extended t i k h0 h1 /\
+      pred k h1 /\ M.loc_disjoint (loc t) parent)
     (ensures dt_forall t pred h1)
 
 val lemma_forall_frame:
   #it: eqtype ->
   #vt: (it -> Type) ->
   t: dt vt ->
-  pred: (i:it -> vt i -> mem -> GTot Type0) ->
-  pred_fp: M.loc ->
-  pred_frame: (i:it -> k:vt i -> h0:mem -> l:M.loc -> h1:mem -> Lemma
-    (requires pred i k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l pred_fp)
-    (ensures pred i k h1)) ->
+  pred: (#i:it -> vt i -> mem -> GTot Type0) ->
+  #parent: M.loc ->
+  fp: local_fp vt parent ->
+  pred_frame: (#i:it -> k:vt i -> h0:mem -> l:M.loc -> h1:mem -> Lemma
+    (requires pred k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l (fp k))
+    (ensures pred k h1)) ->
   h0: mem -> l:M.loc -> h1: mem ->
   Lemma
     (requires dt_forall t pred h0
-      /\ M.modifies l h0 h1 /\ t `used_in` h0
-      /\ M.loc_disjoint (loc t) l /\ M.loc_disjoint pred_fp l)
+      /\ M.modifies l h0 h1 /\ t `live` h0
+      /\ M.loc_disjoint l (loc t) /\ M.loc_disjoint l (footprint t fp h0))
     (ensures dt_forall t pred h1)
 
-val footprint:
-  #it: eqtype ->
-  #vt: (it -> Type) ->
-  t: dt vt ->
-  fp: (i:it -> vt i -> M.loc) -> // Instance footprint
-  h: mem ->
-  GTot M.loc // Package footprint = union of all instance footprints
-
-val lemma_footprint_extend: 
-  #it: eqtype ->
-  #vt: (it -> Type) ->
-  t: dt vt ->
-  fp: (i:it -> vt i -> M.loc) ->
-  i: it ->
-  k: vt i ->
-  h0: mem ->
-  h1: mem ->
-  Lemma
-    (requires extended t i k h0 h1)
-    (ensures footprint t fp h1 == M.loc_union (footprint t fp h0) (fp i k))
-
-val lemma_footprint_includes:
-  #it: eqtype ->
-  #vt: (it -> Type) ->
-  t: dt vt ->
-  fp: (i:it -> vt i -> M.loc) ->
-  i: it ->
-  k: vt i ->
-  h: mem ->
-  Lemma
-    (requires defined_as t i k h)
-    (ensures (footprint t fp h) `M.loc_includes` (fp i k))
-
+(*
 val dt_fold:
   #it: eqtype ->
   #vt: (it -> Type) ->
@@ -189,3 +232,4 @@ val dt_fold:
   f: (rt -> i:it -> vt i -> rt) ->
   h: mem ->
   GTot rt
+*)

--- a/src/tls/DefineTable.fsti
+++ b/src/tls/DefineTable.fsti
@@ -123,6 +123,14 @@ val empty_fp:
   vt:(it->Type) ->
   local_fp vt
 
+val lemma_empty_fp_none:
+  #it:eqtype ->
+  #vt:(it -> Type) ->
+  #i:it ->
+  k:vt i ->
+  Lemma (empty_fp vt k == M.loc_none)
+  [SMTPat (empty_fp vt k)]
+
 // Package footprint = union of all instance footprints
 val footprint:
   #it: eqtype ->

--- a/src/tls/DefineTable.fsti
+++ b/src/tls/DefineTable.fsti
@@ -1,0 +1,191 @@
+module DefineTable
+
+open Mem
+
+module M = LowStar.Modifies
+module DM = FStar.DependentMap
+module MDM = FStar.Monotonic.DependentMap
+module MH = FStar.Monotonic.Heap
+module HS = FStar.HyperStack
+
+(*
+Define tables are a core feature of the cryptographic model.
+
+Their purpose is to record the creation of instances of a
+packaged functionality, and memoize the created instances
+to guarantee that instances are unique for a given index.
+
+Whenever possible, we try to sepaate the state of functionalities
+by instance (see LocalPkg). In that case, the invariant and
+footprint for the collection of instances can be managed entirely
+based on the define table. This requires some specialization
+over FStar.Monotonic.DependentMap, in particular to compute
+and reason about joint footprints and invariants.
+*)
+
+type table (#it:eqtype) (vt: it -> Type) =
+  MDM.t tls_define_region it vt (fun _ -> True)
+
+inline_for_extraction type dt (#it:eqtype) (vt:it->Type) =
+  (if model then table vt else unit)
+
+let ideal (#it:eqtype) (#vt:it->Type) (t:dt vt) : Pure (table vt)
+  (requires model) (ensures fun _ -> True) = t
+
+let loc (#it:eqtype) (#vt:it->Type) (t:dt vt) =
+  if model then M.loc_mreference (ideal t) else M.loc_none
+
+type fresh (#it:eqtype) (#vt:it -> Type) (t:dt vt) (i:it) (h:mem) =
+  model ==> MDM.fresh (ideal t) i h
+
+type defined_as (#it:eqtype) (#vt:it -> Type) (t:dt vt) (i:it) (k:vt i) (h:mem) =
+  model ==> (MDM.sel (HS.sel h (ideal t)) i == Some k)
+
+type defined (#it:eqtype) (#vt:it -> Type) (t:dt vt) (i:it) =
+  model ==> witnessed (MDM.defined (ideal t) i)
+
+type extended (#it:eqtype) (#vt:it -> Type) (t:dt vt)
+  (i:it) (v:vt i) (h0 h1:mem) =
+  (if model then
+    M.modifies (loc t) h0 h1 /\
+    MDM.fresh (ideal t) i h0 /\
+    MDM.defined (ideal t) i h1 /\
+    HS.sel h1 (ideal t) == MDM.upd (HS.sel h0 (ideal t)) i v
+  else M.modifies M.loc_none h0 h1)
+
+type unchanged (#it:eqtype) (#vt:it -> Type) (t:dt vt) (h0 h1:mem) =
+  model ==> HS.sel h0 (ideal t) == HS.sel h1 (ideal t)
+
+type empty (#it:eqtype) (#vt:it -> Type) (t:dt vt) (h1:mem) =
+  model ==> HS.sel h1 (ideal t) == MDM.empty
+
+type disjoint (#it:eqtype) (#vt:it -> Type) (t:dt vt)
+  (#it':eqtype) (#vt':it' -> Type) (t':dt vt') =
+  M.loc_disjoint (loc t) (loc t')
+
+let alloc (#it:eqtype) (vt:it -> Type) : ST (dt vt)
+  (requires fun h0 -> True)
+  (ensures fun h0 t h1 -> M.modifies (loc t) h0 h1 /\ empty t h1)
+  =
+  if model then (MDM.alloc #it #vt #(fun _ -> True) #tls_define_region ())
+  else ()
+
+type used_in (#it:eqtype) (#vt:it -> Type) (t:dt vt) (h:mem) =
+  model ==> h `HS.contains` (ideal t)
+
+let lemma_disjoint_unchanged (#it:eqtype) (#vt:it -> Type) (t:dt vt)
+  (#it':eqtype) (#vt':it' -> Type) (t':dt vt') (h0:mem) (h1:mem) : Lemma
+  (requires M.modifies (loc t) h0 h1 /\
+    disjoint t t' /\ used_in t h0 /\ used_in t' h0)
+  (ensures unchanged t' h0 h1) = ()
+
+let lemma_frame_dt (#it:eqtype) (#vt:it -> Type) (t:dt vt)
+  (h0:mem) (l:M.loc) (h1:mem) : Lemma
+  (requires M.modifies l h0 h1 /\ used_in t h0 /\ M.loc_disjoint l (loc t))
+  (ensures unchanged t h0 h1) = ()
+
+(* Used to define a joint invariant over all defined instances
+The definition is opaque but the lemmas below are enough to use
+and extend the joint invariant in the memoization functor *)
+val dt_forall:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  pred: (i:it -> vt i -> mem -> GTot Type0) ->
+  h: mem ->
+  Type0
+
+val lemma_forall_empty:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  pred: (i:it -> vt i -> mem -> GTot Type0) ->
+  h: mem ->
+  Lemma 
+    (requires empty t h)
+    (ensures dt_forall t pred h)
+
+val lemma_forall_elim:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  pred: (i:it -> vt i -> mem -> GTot Type0) ->
+  i: it -> k: vt i ->
+  h: mem ->
+  Lemma
+    (requires dt_forall t pred h /\ model)
+    (ensures defined_as t i k h ==> pred i k h)
+
+val lemma_forall_extend:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  pred: (i:it -> vt i -> mem -> GTot Type0) ->
+  pred_frame: (i:it -> k:vt i -> h0:mem -> h1:mem -> Lemma
+    (requires pred i k h0 /\ M.modifies (loc t) h0 h1)
+    (ensures pred i k h1)) ->
+  i: it -> k: vt i ->
+  h0: mem -> h1: mem ->
+  Lemma
+    (requires dt_forall t pred h0 /\
+      extended t i k h0 h1 /\ pred i k h1)
+    (ensures dt_forall t pred h1)
+
+val lemma_forall_frame:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  pred: (i:it -> vt i -> mem -> GTot Type0) ->
+  pred_fp: M.loc ->
+  pred_frame: (i:it -> k:vt i -> h0:mem -> l:M.loc -> h1:mem -> Lemma
+    (requires pred i k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l pred_fp)
+    (ensures pred i k h1)) ->
+  h0: mem -> l:M.loc -> h1: mem ->
+  Lemma
+    (requires dt_forall t pred h0
+      /\ M.modifies l h0 h1 /\ t `used_in` h0
+      /\ M.loc_disjoint (loc t) l /\ M.loc_disjoint pred_fp l)
+    (ensures dt_forall t pred h1)
+
+val footprint:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  fp: (i:it -> vt i -> M.loc) -> // Instance footprint
+  h: mem ->
+  GTot M.loc // Package footprint = union of all instance footprints
+
+val lemma_footprint_extend: 
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  fp: (i:it -> vt i -> M.loc) ->
+  i: it ->
+  k: vt i ->
+  h0: mem ->
+  h1: mem ->
+  Lemma
+    (requires extended t i k h0 h1)
+    (ensures footprint t fp h1 == M.loc_union (footprint t fp h0) (fp i k))
+
+val lemma_footprint_includes:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  fp: (i:it -> vt i -> M.loc) ->
+  i: it ->
+  k: vt i ->
+  h: mem ->
+  Lemma
+    (requires defined_as t i k h)
+    (ensures (footprint t fp h) `M.loc_includes` (fp i k))
+
+val dt_fold:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  #rt: Type ->
+  init: rt ->
+  f: (rt -> i:it -> vt i -> rt) ->
+  h: mem ->
+  GTot rt

--- a/src/tls/DefineTable.fsti
+++ b/src/tls/DefineTable.fsti
@@ -118,6 +118,11 @@ val dt_forall:
 type local_fp (#it:eqtype) (vt:it->Type) =
   #i:it -> vt i -> l:M.loc{not model ==> l == M.loc_none}
 
+val empty_fp:
+  #it:eqtype ->
+  vt:(it->Type) ->
+  local_fp vt
+
 // Package footprint = union of all instance footprints
 val footprint:
   #it: eqtype ->
@@ -126,6 +131,13 @@ val footprint:
   fp: local_fp vt ->
   h: mem ->
   GTot M.loc
+
+val lemma_footprint_empty_fp:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  h: mem ->
+  Lemma (footprint t (empty_fp vt) h == M.loc_none)
 
 val lemma_footprint_empty:
   #it: eqtype ->

--- a/src/tls/DefineTable.fsti
+++ b/src/tls/DefineTable.fsti
@@ -229,6 +229,21 @@ val lemma_forall_extend:
       pred k h1 /\ M.loc_disjoint (loc t) (footprint t fp h0))
     (ensures dt_forall t pred h1)
 
+val lemma_forall_restore:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  pred: (#i:it -> vt i -> mem -> GTot Type0) ->
+  fp: local_fp vt ->
+  pred_frame: (#i:it -> k:vt i -> #j:it -> k':vt j -> Lemma
+    (requires i <> j)
+    (ensures M.loc_disjoint (fp k) (fp k'))) ->
+  #i: it -> k: vt i ->
+  h0: mem -> h1: mem ->
+  Lemma
+    (requires dt_forall t pred h0 /\ M.modifies (fp k) h0 h1 /\ pred k h1)
+    (ensures dt_forall t pred h1)
+
 val lemma_forall_frame:
   #it: eqtype ->
   #vt: (it -> Type) ->
@@ -244,3 +259,28 @@ val lemma_forall_frame:
       /\ M.modifies l h0 h1 /\ t `live` h0
       /\ M.loc_disjoint l (loc t) /\ M.loc_disjoint l (footprint t fp h0))
     (ensures dt_forall t pred h1)
+
+(*
+
+type projection (#it:eqtype) (#vt:it->Type) (t:dt vt) (pred:it->bool) =
+  m:DM.t it (MDM.opt vt){forall (i:it). Some? (DM.sel m i) ==> pred i}
+
+val filter:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  pred: (i:it -> bool) ->
+  h: mem ->
+  GTot (projection t pred)
+
+val lemma_filter_sel:
+  #it: eqtype ->
+  #vt: (it -> Type) ->
+  t: dt vt ->
+  pred: (i:it -> bool) ->
+  h: mem ->
+  i: it ->
+  Lemma (requires model)
+  (ensures DM.sel (filter t pred h) i ==
+    (if pred i then MDM.sel (HS.sel h (ideal t)) i else None))
+*)

--- a/src/tls/Format.UncompressedPointRepresentation.fst
+++ b/src/tls/Format.UncompressedPointRepresentation.fst
@@ -122,9 +122,8 @@ private
 let lbytes_pair_serializer (coordinate_length:coordinate_length_type)
   : LP.serializer (lbytes_pair_parser coordinate_length) 
   = let l = U32.v coordinate_length in
-    let p = LP.parse_flbytes l in
     let s = LP.serialize_flbytes l in
-    LP.serialize_nondep_then p s () p s
+    LP.serialize_nondep_then s s
 
 #reset-options "--using_facts_from '* -FStar.Reflection -FStar.Tactics' --max_fuel 16 --initial_fuel 16 --max_ifuel 16 --initial_ifuel 16 --z3rlimit 10"
 private
@@ -133,9 +132,8 @@ let lbytes_pair_serializer32 (coordinate_length:coordinate_length_type)
   : LP.serializer32 (lbytes_pair_serializer coordinate_length) 
   = [@inline_let]
     let l = U32.v coordinate_length in
-    LP.serialize32_nondep_then
-      (LP.serialize32_flbytes l) ()
-      (LP.serialize32_flbytes l) ()
+    [@inline_let] let s32 = LP.serialize32_flbytes l in
+    s32 `LP.serialize32_nondep_then` s32
 #reset-options
 
 #reset-options "--using_facts_from '* -FStar.Reflection -FStar.Tactics'"
@@ -148,10 +146,7 @@ let uncompressedPointRepresentation_serializer (coordinate_length:coordinate_len
       (LP.nondep_then (constantByte_parser 4uy) (lbytes_pair_parser l))
       ucp_of_cuv
       (LP.serialize_nondep_then 
-        (constantByte_parser 4uy)
         (constantByte_serializer 4uy) 
-        ()
-        (lbytes_pair_parser l)
         (lbytes_pair_serializer l))
       cuv_of_ucp
       ()
@@ -166,10 +161,10 @@ let uncompressedPointRepresentation_serializer32 (coordinate_length:coordinate_l
     LP.serialize32_synth 
       (LP.nondep_then (constantByte_parser 4uy) (lbytes_pair_parser l))      
       ucp_of_cuv
-      (LP.serialize_nondep_then (constantByte_parser 4uy) (constantByte_serializer 4uy) ()
-                                (lbytes_pair_parser l) (lbytes_pair_serializer l))
-      (LP.serialize32_nondep_then (constantByte_serializer32 4uy) ()
-                                  (lbytes_pair_serializer32 l) ())
+      (LP.serialize_nondep_then (constantByte_serializer 4uy)
+                                (lbytes_pair_serializer l))
+      (LP.serialize32_nondep_then (constantByte_serializer32 4uy)
+                                  (lbytes_pair_serializer32 l))
       cuv_of_ucp
       (fun x -> cuv_of_ucp x)
       ()

--- a/src/tls/HandshakeLog.fst
+++ b/src/tls/HandshakeLog.fst
@@ -308,8 +308,6 @@ let setParams l pv ha kexo dho =
         st.transcript st.out st.incoming st.parsed
         hs (Some pv) kexo dho
 
-#set-options "--admit_smt_queries true"
-
 (*
 val getHash: #ha:hash_alg -> t:log -> ST (tag ha)
     (requires (fun h -> hashAlg h t == Some ha))
@@ -323,25 +321,24 @@ let getHash #ha (LOG #reg st) =
     Hashing.finalize #ha cst.hash
 *)
 
+#set-options "--admit_smt_queries true"
 // Must be called after receiving a CH in the Init state of nego, indicating
 // that the retry is stateless.
-let load_stateless_cookie l hrr digest = admit()
-(*
+let load_stateless_cookie (l:log) hrr digest =
   let st = !l in
   // The cookie is loaded after CH2 is written to the hash buffer
-  let OpenHash ch2b = st.hashes in
+  let OpenHash ch2b = st.hashes in  
   let fake_ch = (bytes_of_hex "fe0000") @| (Parse.vlbytes 1 digest) in
   trace ("Installing prefix to transcript: "^(hex_of_bytes fake_ch));
-  let hrb = handshakeMessageBytes None (HelloRetryRequest hrr) in
+  let hrb = handshake_serializer32 (M_server_hello (serverHello_of_hrr hrr)) in
   trace ("HRR bytes: "^(hex_of_bytes hrb));
-  let h = OpenHash (fake_ch @| hrb @| ch2b) in
-  l := State st.transcript st.outgoing st.outgoing_next_keys st.outgoing_complete
-             st.incoming st.parsed h st.pv st.kex st.dh_group
-*)
-
+  let h = OpenHash (fake_ch @| hrb @| ch2b) in  
+  l := State st.transcript st.out st.incoming st.parsed h st.pv st.kex st.dh_group
 
 ///
 /// SEND --> high & low adaptor between Old.Handshake and Transcript
+
+module HRR = Parsers.HelloRetryRequest
 
 let send_truncated l m tr =
   trace ("emit "^string_of_handshakeType (tag_of m));
@@ -356,12 +353,14 @@ let send_truncated l m tr =
       FixedHash a acc hl
     | OpenHash p ->
       (match m with
-      (*
-      | HelloRetryRequest hrr ->
-        let Some cs = cipherSuite_of_name hrr.hrr_cipher_suite in
-        let hmsg = Hashing.compute (verifyDataHashAlg_of_ciphersuite cs) p in
-        let hht = (bytes_of_hex "fe0000") @| (bytes_of_int 1 (length hmsg)) @| hmsg in
-        OpenHash (hht @| mb) *)
+      | Msg (M_server_hello sh) ->
+        if is_hrr sh then
+          let hrr = get_hrr sh in
+          let Some cs = cipherSuite_of_name hrr.HRR.cipher_suite in
+          let hmsg = Hashing.compute (verifyDataHashAlg_of_ciphersuite cs) p in
+          let hht = (bytes_of_hex "fe0000") @| (bytes_of_int 1 (length hmsg)) @| hmsg in
+          OpenHash (hht @| mb)
+	else OpenHash (p @| mb)
       | _ -> OpenHash (p @| mb))
     in
   let sto = st.out in
@@ -613,15 +612,21 @@ let rec hashHandshakeMessages t p hs n nb =
     | m::mrest, mb::brest ->
       (match hs with
       | OpenHash b ->
-        let hs = match m with (*
-          | HelloRetryRequest hrr ->
-            let hmsg = match cipherSuite_of_name hrr.hrr_cipher_suite with
-              | Some cs -> Hashing.compute (verifyDataHashAlg_of_ciphersuite cs) b
-              | None -> b in
-            let hht = (bytes_of_hex "fe0000") @| (Parse.vlbytes 1 hmsg) in
-            trace ("Replacing CH1 in transcript with "^(hex_of_bytes hht));
-            trace ("HRR bytes: "^(hex_of_bytes mb));
-            OpenHash (hht @| mb) *)
+        let hs =
+	  match m with
+          | Msg (M_server_hello sh) ->
+	    if is_hrr sh then
+	     begin
+	      let hrr = get_hrr sh in
+              let hmsg = match cipherSuite_of_name hrr.HRR.cipher_suite with
+                | Some cs -> Hashing.compute (verifyDataHashAlg_of_ciphersuite cs) b
+                | None -> b in
+              let hht = (bytes_of_hex "fe0000") @| (Parse.vlbytes 1 hmsg) in
+              trace ("Replacing CH1 in transcript with "^(hex_of_bytes hht));
+              trace ("HRR bytes: "^(hex_of_bytes mb));
+              OpenHash (hht @| mb)
+	     end
+	    else OpenHash (b @| mb)
           | _ -> OpenHash (b @| mb)
         in
         hashHandshakeMessages t (p @ [m]) hs mrest brest

--- a/src/tls/HandshakeLog.fsti
+++ b/src/tls/HandshakeLog.fsti
@@ -84,9 +84,11 @@ let weak_valid_transcript hsl =
     | (Msg (M_client_hello ch)) :: (Msg (M_server_hello sh)) :: rest -> true
     | _ -> false
 
+module SH = Parsers.ServerHello
 let transcript_version (x: list msg {weak_valid_transcript x}) = 
     match x with
-    | (Msg (M_client_hello ch)) :: (Msg (M_server_hello sh)) :: rest -> Some sh.version
+    | (Msg (M_client_hello ch)) :: (Msg (M_server_hello sh)) :: rest ->
+      Some sh.SH.version
     | _ -> None
 
 (* TODO: move to something like FStar.List.GTot *)
@@ -200,7 +202,6 @@ val setParams: s:log ->
     writing h1 s == writing h0 s /\
     hashAlg h1 s == Some a ))
 
-
 (* Outgoing *)
 
 // We send one message at a time (or in two steps for CH);
@@ -215,11 +216,10 @@ let write_transcript h0 h1 (s:log) (m:msg) =
     writing h1 s /\
     hashAlg h1 s == hashAlg h0 s /\
     transcript h1 s == transcript h0 s @ [m]
-(*
+
 val load_stateless_cookie: s:log -> h:hrr -> digest:bytes -> ST unit
   (requires (fun h0 -> writing h0 s /\ valid_transcript (transcript h0 s)))
   (ensures (fun h0 _ h1 -> modifies_one s h0 h1 /\ writing h1 s))
-*)
 
 val send_truncated: s:log -> m:msg -> t:UInt32.t -> ST unit
   (requires (fun h0 ->

--- a/src/tls/HandshakeMessages.fsti
+++ b/src/tls/HandshakeMessages.fsti
@@ -18,8 +18,13 @@ include Parsers.Handshake
 include Parsers.Handshake12
 include Parsers.Handshake13
 
-include Parsers.ClientHello
+(* ServerHello also encodes HelloRetryRequest *)
 include Parsers.ServerHello
+include Parsers.ServerHello_is_hrr
+include Parsers.HRRKind
+include Parsers.SHKind
+
+include Parsers.ClientHello
 include Parsers.NewSessionTicket12
 include Parsers.NewSessionTicket13
 include Parsers.EncryptedExtensions

--- a/src/tls/Hashing.Spec.fst
+++ b/src/tls/Hashing.Spec.fst
@@ -12,6 +12,17 @@ include Spec.Hash.Definitions
 open FStar.Integers
 open FStar.Bytes
 
+let hash_len (a:alg)
+  : n:UInt32.t{UInt32.v n == hash_length a}
+  =
+  match a with
+  | MD5 -> assert_norm(hash_length MD5 == 16); 16ul
+  | SHA1 -> assert_norm(hash_length SHA1 == 20); 20ul
+  | SHA2_224 -> assert_norm(hash_length SHA2_224 == 28); 28ul
+  | SHA2_256 -> assert_norm(hash_length SHA2_256 == 32); 32ul
+  | SHA2_384 -> assert_norm(hash_length SHA2_384 == 48); 48ul
+  | SHA2_512 -> assert_norm(hash_length SHA2_512 == 64); 64ul
+
 type tag (a:alg) = Bytes.lbytes (hash_length a)
 
 let max_hash_length = 64

--- a/src/tls/Hashing.Spec.fst
+++ b/src/tls/Hashing.Spec.fst
@@ -11,15 +11,33 @@ include Spec.Hash.Definitions
 
 open FStar.Integers
 open FStar.Bytes
+
 type tag (a:alg) = Bytes.lbytes32 (tagLen a)
+
+let maxTagLength = 64
 let maxTagLen = 64ul
-type anyTag = lbytes (Integers.v maxTagLen)
+type anyTag = lbytes maxTagLength
+
+let maxBlockLength = 128
+let maxBlockLen = 128ul
+
+private let lemma_tagLen (a:alg)
+  : Lemma (UInt32.v (tagLen a) <= maxTagLength)
+  [SMTPat (tagLen a)]
+  = ()
+
+private let lemma_blockLength (a:alg)
+  : Lemma (blockLength a <= maxBlockLength)
+  [SMTPat (blockLength a)]
+  = ()
 
 // JP: override the definition from evercrypt (which uses <) with miTLS
 // compatible definitions (which uses <=)
 let maxLength a = EverCrypt.Hash.maxLength a - 1
 
 let macable a = b:bytes {length b + blockLength a < pow2 32}
+let macable_any = b:bytes{length b + maxBlockLength < pow2 32}
+
 // 32-bit implementation restriction
 
 // Adapting EverCrypt's HMAC specification to TLS. In contrast with

--- a/src/tls/IV.fst
+++ b/src/tls/IV.fst
@@ -3,7 +3,8 @@ module IV
 open Mem
 open Pkg
 
-
+module M = LowStar.Modifies
+module DT = DefineTable
 
 /// A sample functionality for fresh, public initialization vectors,
 /// with the length of the byte vector as a basic agility
@@ -13,74 +14,69 @@ open Pkg
 /// There is no need for an idealization flag: the main (unconditional)
 /// property is that the vector is a function of the index; this
 /// vector is fresh whenever create is called instead of coerce.
+
 type idealRaw = b2t Flags.flag_Raw
+type len_of_id (ip:ipkg) = i:ip.t{model} -> keylen
 
 // SZ: [len_of_i] was implicit, but it can't be inferred from [i]. Made it explicit
-type rawlen (#ip:ipkg) (len_of_i:ip.t -> keylen) (i:ip.t) = len:keylen {len == len_of_i i}
-
-type raw (ip:ipkg) (len_of_i:ip.t -> keylen) (i:ip.t{ip.registered i}) = Bytes.lbytes32 (len_of_i i)
-
-noextract inline_for_extraction
-let shared_footprint_raw (ip:ipkg) (len_of_i:ip.t -> keylen): rset = Set.empty
+type rawlen (#ip:ipkg) (lid:len_of_id ip) (i:ip.t) = len:keylen {model ==> len == lid i}
+type raw (#ip:ipkg) (lid:len_of_id ip) (i:ip.t{ip.registered i}) = Bytes.bytes
+//  b:Bytes.bytes{model ==> Bytes.len b == lid i}
 
 noextract inline_for_extraction
-let footprint_raw (ip:ipkg) (len_of_i:ip.t -> keylen)
-  (#i:ip.t {ip.registered i}) (k:raw ip len_of_i i)
-  : GTot (s:rset{s `Set.disjoint` shared_footprint_raw ip len_of_i})
-  =
-  let fp = Set.empty in
-  let sfp = shared_footprint_raw ip len_of_i in
-  Set.lemma_equal_elim (fp `Set.intersect` sfp) Set.empty;
-  fp
-
-noextract inline_for_extraction
-let create_raw (ip:ipkg) (len_of_i:ip.t -> keylen)
-  (i:ip.t{ip.registered i}) (len:keylen {len = len_of_i i}):
-  ST (raw ip len_of_i i)
-  (requires fun h0 -> model)
-  (ensures fun h0 p h1 -> modifies_none h0 h1)
+let create_raw (#ip:ipkg) (lid:len_of_id ip)
+  (i:ip.t{ip.registered i}) (len:rawlen lid i):
+  ST (raw lid i)
+  (requires fun h0 -> model /\ lid i == len)
+  (ensures fun h0 p h1 -> M.modifies M.loc_none h0 h1 /\
+    fresh_loc M.loc_none h0 h1)
   = Random.sample32 len
 
-let coerceT_raw (ip:ipkg) (len_of_i:ip.t -> keylen)
+let coerceT_raw (#ip:ipkg) (lid:len_of_id ip)
   (i: ip.t {ip.registered i /\ (idealRaw ==> ~(ip.honest i))})
-  (len:keylen{len == len_of_i i}) (r: Bytes.lbytes32 len):
-  GTot (raw ip len_of_i i) = r
+  (len:rawlen lid i) (r:Bytes.lbytes32 len)
+  : GTot (raw lid i) 
+  = r
 
 inline_for_extraction
-let coerce_raw (ip: ipkg) (len_of_i: ip.t -> keylen)
+let coerce_raw (#ip: ipkg) (lid:len_of_id ip)
   (i: ip.t {ip.registered i /\ (idealRaw ==> ~(ip.honest i))})
-  (len:keylen {len == len_of_i i}) (r: Bytes.lbytes32 len):
-  ST (raw ip len_of_i i)
+  (len:rawlen lid i) (r: Bytes.lbytes32 len):
+  ST (raw lid i)
   (requires fun h0 -> True)
-  (ensures fun h0 k h1 -> k == coerceT_raw ip len_of_i i len r /\ modifies_none h0 h1)
+  (ensures fun h0 k h1 -> k == coerceT_raw lid i len r /\
+    M.modifies M.loc_none h0 h1)
   = r
 
 noextract
 inline_for_extraction
-let local_raw_pkg (ip:ipkg) (len_of_i:ip.t -> keylen) : local_pkg ip =
+let local_raw_pkg (#ip:ipkg) (lid:len_of_id ip)
+  : Pure (local_pkg ip)
+  (requires True) (ensures fun p -> LocalPkg?.key p == raw lid)
+  =
   LocalPkg
-    (raw ip len_of_i)
-    (rawlen #ip len_of_i)
-    (fun #i (n:rawlen len_of_i i) -> n)
+    (raw lid)
+    (rawlen lid)
+    (fun (i:ip.t{model}) -> lid i)
+    (fun #i (n:rawlen lid i) -> n)
     idealRaw
-    (shared_footprint_raw ip len_of_i)
-    (footprint_raw ip len_of_i)
+    (DT.empty_fp (raw lid))
     (fun #_ _ _ -> True) // no invariant
-    (fun _ _ _ _ _ -> ())
-    (fun #_ _ _ _ -> True) // no post-condition
-    (fun #_ _ _ _ _ _ -> ())
-    (create_raw ip len_of_i)
-    (coerceT_raw ip len_of_i)
-    (coerce_raw ip len_of_i)
+    (fun #_ _ _ _ _ -> ())
+    (create_raw lid)
+    (coerceT_raw lid)
+    (coerce_raw lid)
 
 noextract inline_for_extraction
-let rp (ip:ipkg) (len_of_i:ip.t -> keylen): ST (pkg ip)
+let rp (ip:ipkg) (lid:len_of_id ip): ST (pkg ip)
   (requires fun h0 -> True)
-  (ensures fun h0 p h1 -> modifies_one tls_define_region h0 h1 /\ p.package_invariant h1)
+  (ensures fun h0 p h1 ->
+    Pkg?.key p == raw lid /\
+    p == memoization (local_raw_pkg lid) p.define_table /\
+    p.package_invariant h1 /\
+    fresh_loc (DT.loc p.define_table) h0 h1)
   =
-  memoization_ST (local_raw_pkg ip len_of_i)
-
-// does this extract? 18-09-24 no
+  memoization_ST (local_raw_pkg lid)
 
 val discard: bool -> ST unit
   (requires (fun _ -> True))  (ensures (fun h0 _ h1 -> h0 == h1))
@@ -94,7 +90,7 @@ inline_for_extraction
 noextract
 private let ip : ipkg = Pkg.Idx id (fun _ -> True) (fun _ -> True) (fun _ -> true)
 
-private let len_of_i (i:id): keylen =
+private let len_of_i  (i:id): keylen =
   if i > 0 && i < 32 then UInt32.uint_to_t i
   else 32ul
 
@@ -108,13 +104,11 @@ let test() : ST unit
   print (Bytes.hex_of_bytes k);
 
   [@inline_let]
-  let p = local_raw_pkg ip len_of_i in
+  let p = local_raw_pkg #ip len_of_i in
   let v0 = LocalPkg?.coerce p 12 kl k in
   print (Bytes.hex_of_bytes v0);
-
-  let table = mem_alloc (fun n -> Bytes.lbytes n) in
-  [@inline_let]
-  let q = Pkg.memoization p table in
+  
+  let q = rp ip len_of_i in
   let v1 = Pkg?.coerce q 12 kl k in
   print (Bytes.hex_of_bytes v1);
   ()

--- a/src/tls/IV.fst
+++ b/src/tls/IV.fst
@@ -94,6 +94,7 @@ private let len_of_i  (i:id): keylen =
   if i > 0 && i < 32 then UInt32.uint_to_t i
   else 32ul
 
+noextract
 let test() : ST unit
   (requires fun h0 -> True)
   (ensures fun h0 _ h1 -> True)
@@ -103,8 +104,7 @@ let test() : ST unit
   let k = Bytes.create 12ul 0uy in
   print (Bytes.hex_of_bytes k);
 
-  [@inline_let]
-  let p = local_raw_pkg #ip len_of_i in
+  [@inline_let] let p = local_raw_pkg #ip len_of_i in
   let v0 = LocalPkg?.coerce p 12 kl k in
   print (Bytes.hex_of_bytes v0);
   

--- a/src/tls/KDF.fst
+++ b/src/tls/KDF.fst
@@ -22,6 +22,7 @@ module DM = FStar.DependentMap
 module MDM = FStar.Monotonic.DependentMap
 module HS = FStar.HyperStack
 module DT = DefineTable
+module HD = Spec.Hash.Definitions
 
 #set-options "--max_fuel 1 --max_ifuel 1 --z3rlimit 30"
 
@@ -617,7 +618,7 @@ val derive:
     _:squash (registered (derive i lbl ctx)) &
     (LocalPkg?.key child_pkg) (derive i lbl ctx))
   (requires fun h0 ->
-    (LocalPkg?.len child_pkg) a' == EverCrypt.Hash.tagLen (get_info k).ha /\
+    UInt32.v ((LocalPkg?.len child_pkg) a') == HD.hash_length (get_info k).ha /\
     ((u_of_t t) `has_lbl` lbl ==>
       compatible_packages child_pkg (child (u_of_t t) lbl)) /\
     DT.defined (kdf_dt t) i /\

--- a/src/tls/KDF.fst
+++ b/src/tls/KDF.fst
@@ -23,7 +23,7 @@ module MDM = FStar.Monotonic.DependentMap
 module HS = FStar.HyperStack
 module DT = DefineTable
 
-#set-options "--max_fuel 0 --max_ifuel 0 --z3rlimit 30"
+#set-options "--max_fuel 1 --max_ifuel 1 --z3rlimit 30"
 
 (*
 This module defines a universal, packaged KDF parametric in its
@@ -49,8 +49,6 @@ type info =
   ha:kdfa ->
   option (details ha) -> info
 
-#push-options "--max_fuel 1 --max_ifuel 1"
-
 noextract
 let rec index_info (i:id{model}) =
   let i':pre_id = i in
@@ -58,8 +56,6 @@ let rec index_info (i:id{model}) =
   | Preshared a _ -> Info a None
   | Derive i l (ExpandLog log hv) -> Info (ha_of_id i) (Some (Log log hv))
   | Derive i _ _ -> index_info i
-
-#pop-options
 
 let valid_info (i:id) (v:info) = model ==> (v == index_info i)
 
@@ -75,31 +71,10 @@ let derived_key
   (lbl: label {u `has_lbl` lbl})
   (ctx: context)
   : Pure Type0
-  (requires wellformed_derive i lbl ctx /\ registered (derive i lbl ctx))
+  (requires model /\ wellformed_derive i lbl ctx /\
+    registered (derive i lbl ctx))
   (ensures fun t -> True)
-  =
-  if model then
-    Pkg?.key (child u lbl) (Derive i lbl ctx)
-  else unit
-
-let kdf_region : tls_rgn = new_region tls_tables_region
-let kdf_loc = M.loc_region_only true kdf_region
-
-/// key-derivation table (memoizing create/coerce)
-noextract
-type domain (#ideal:iflag) (u:usage ideal) (i:regid) : eqtype =
-| Domain:
-  lbl: label {u `has_lbl` lbl} ->
-  ctx: context {wellformed_derive i lbl ctx /\ registered (derive i lbl ctx)} ->
-  domain u i
-
-noextract
-let kdf_range (#ideal:iflag) (u:usage ideal) (i:regid) (d:domain u i) =
-  (let Domain lbl ctx = d in derived_key u i lbl ctx)
-
-noextract
-abstract type table (#ideal:iflag) (u:usage ideal) (i:regid) =
-  MDM.t kdf_region (domain u i) (kdf_range u i) (fun _ -> True)
+  = Pkg?.key (child u lbl) (Derive i lbl ctx)
 
 inline_for_extraction
 let secret_len (a:info) : keylen = Hashing.Spec.tagLen a.ha
@@ -108,54 +83,188 @@ type real_secret (i:regid) = a:info0 i & lbytes32 (secret_len a)
 let safe (#ideal:iflag) (u:usage ideal) (i:regid) =
   honest i /\ b2t ideal
 
+// This is the type of KDF instances
+// The idealized KDF does not have any state; 
+// we rely on the children packages to compute
+// a virtual idealization table
 type secret (#ideal:iflag) (u:usage ideal) (i:regid) =
-  Model.ir (safe u) (table u i) (real_secret i) i
+  Model.ir (safe u) unit (real_secret i) i
 
-/// Real KDF schemes, parameterized by an algorithm computed from the
-/// index (existing code).
+(* Honestly invariants for derived instances *)
 
 val lemma_witnessed_true (p:mem_predicate) :
   Lemma (requires (forall h. p h)) (ensures witnessed p)
 let lemma_witnessed_true p =
-  lemma_witnessed_constant True;
-  weaken_witness (fun _ -> True) p
+  lemma_witnessed_constant True;  weaken_witness (fun _ -> True) p
 
-#push-options "--max_ifuel 1"
-
-val lemma_honest_parent (i:regid) (lbl:label) (ctx:context)
-  : Lemma (requires
-            wellformed_derive i lbl ctx /\
-            registered (derive i lbl ctx) /\
-            ~(honest_idh ctx) /\
-            honest (derive i lbl ctx))
-          (ensures honest i)
-let lemma_honest_parent i lbl ctx =
+private let lemma_honest_parent (i:regid) (lbl:label) (ctx:context)
+  : Lemma
+  (requires wellformed_derive i lbl ctx /\ 
+    registered (derive i lbl ctx) /\ 
+    ~(honest_idh ctx) /\ 
+    honest (derive i lbl ctx))
+  (ensures honest i)
+  =
   if model then
     let log : i_honesty_table = honesty_table in
-    lemma_witnessed_true (fun h -> MDM.contains log (derive i lbl ctx) true h ==> MDM.contains log i true h);
-    lemma_witnessed_impl (MDM.contains log (derive i lbl ctx) true) (MDM.contains log i true)
-
-#pop-options
+    lemma_witnessed_true (fun h ->
+      MDM.contains log (derive i lbl ctx) true h ==> MDM.contains log i true h);
+    lemma_witnessed_impl (MDM.contains log (derive i lbl ctx) true)
+      (MDM.contains log i true)
 
 let lemma_honest_parent_impl (i:regid) (lbl:label) (ctx:context)
-  : Lemma (requires wellformed_derive i lbl ctx /\
-            registered (derive i lbl ctx) /\
-            ~(honest_idh ctx))
-          (ensures honest (derive i lbl ctx) ==> honest i)
+  : Lemma
+    (requires wellformed_derive i lbl ctx /\ 
+      registered (derive i lbl ctx) /\ ~(honest_idh ctx))
+    (ensures honest (derive i lbl ctx) ==> honest i)
   = FStar.Classical.impl_intro_gen #(honest (derive i lbl ctx)) #(fun _ -> honest i)
     (fun (u:squash (honest (derive i lbl ctx))) -> lemma_honest_parent i lbl ctx)
+
+(* Concrete info (hash agility) *)
 
 inline_for_extraction
 let get_info (#ideal:iflag) (#u:usage ideal) (#i:regid) (k:secret u i) =
   if Model.is_safe k then index_info i else dfst (Model.real k)
 
+(*** Virtual KDF table ***)
+
+(*
+The ideal behavior of a KDF is to map labels and contexts to derived instances:
+
+  ideal_kdf u i == l:label -> c:context -> k:(child u l).key (derive i l c)
+
+However, to avoid state duplication, we do not actually materialize this table.
+Instead, we compute the table from the define_table of children packages.
+This is a nice simplification because the only state of a KDF table is its own
+define table. (However, the footprint of a KDF package now includes the
+define tables of all of its children).
+
+The define table for package pkg is of the form (i:regid -> pkg.key i),
+and it is global for the package. In contrast, the KDF table is specific
+to the instance of the KDF. Hence, we need to filter the entries of children's
+define table to only the instances whose index is derived from the KDF
+instance's index. We also need to re-index the filtered table to get
+the computed idealization table.
+
+Then, we specify the security of the KDF based on operations on the virtual
+KDF table. The implementation, however, only operates on the children's
+define tables.
+*)
+
+// KDF tables are indexed by label and context
+type kdf_key (#ideal:iflag) (u:usage ideal) (i:regid{model}) (l:label{u `has_lbl` l}) =
+  c:context{wellformed_derive i l c /\ registered (derive i l c)}
+
+// They store derived instances, whose type is directed by the usage
+type kdf_value (#ideal:iflag) (u:usage ideal) (i:regid{model})
+  (l:label{u `has_lbl` l}) (k:kdf_key u i l) =
+  option (derived_key u i l k)
+
+// We shard the table by label
+type kdf_table_shard (#ideal:iflag) (u:usage ideal)
+  (i:regid{model}) (l:label{u `has_lbl` l}) =
+  DM.t (kdf_key u i l) (kdf_value u i l)
+
+// The type of computed KDF tables, indexed by label, then context
+type kdf_table (#ideal:iflag) (u:usage ideal) (i:regid{model}) =
+  DM.t (l:label{u `has_lbl` l}) (kdf_table_shard u i)
+
+type derived_from (#ideal:iflag) (u:usage ideal)
+  (i:regid{model}) (l:label{u `has_lbl` l}) (j:regid) =
+  (let j' : pre_id = j in
+  match j' with
+  | Derive i' lbl ctx -> i' == i /\ lbl == l
+  | _ -> False)
+
+// To compute the virtual KDF table, we need to re-index the
+// projection of the children's KDF tables
+let reindex (#ideal:iflag) (u:usage ideal) (i:regid{model})
+  (l:label{u `has_lbl` l}) (k:kdf_key u i l)
+  : (j:regid{derived_from u i l j}) =
+  derive i l k
+
+// This is not used concretely, but we prove that
+// the re-indexing is bijective by constructing its inverse
+let reindex_inv (#ideal:iflag) (u:usage ideal) (i:regid{model})
+  (l:label{u `has_lbl` l}) (j:regid{derived_from u i l j})
+  : kdf_key u i l =
+  let j' : pre_id = j in
+  let Derive i lbl ctx = j' in
+  ctx
+
+// We prove that the re-indexed virtual KDF table
+// is isomorphic to the filtered define table
+let lemma_reindex_correct (#ideal:iflag) (u:usage ideal)
+  (i:regid{model}) (l:label{u `has_lbl` l}) (k:kdf_key u i l)
+  : Lemma (reindex_inv u i l (reindex u i l k) == k)
+  = ()
+
+// When re-indexing the define table, we get a complicated type for the
+// renamed instances. We show this type is equivalent to kdf_value
+private noextract
+let coerce_reindex (#ideal:iflag) (u:usage ideal) (i:regid{model}) (l:label{u `has_lbl` l})
+  (k:kdf_key u i l) (v:DM.rename_value (MDM.opt (Pkg?.key (child u l))) (reindex u i l) k)
+  : kdf_value u i l k
+  = v
+
+private let lemma_has_lbl_cons (#p:Type0) (u:children' p)
+  (h:label * tree' p) (lbl:label)
+  : Lemma (requires u `has_lbl'` lbl /\ fst h <> lbl)
+  (ensures (h::u) `has_lbl'` lbl /\ child' (h::u) lbl == child' u lbl)
+  = ()
+
+// We desine a custom function for nth because we need to prove that
+// has_lbl and child are preseved by list inclusion
+private let rec nth_child (#p:Type0) (u:children' p{List.Tot.length u > 0})
+  (n:nat{model /\ n < List.Tot.length u})
+  : GTot (l:label{u `has_lbl'` l} & p:pkg ii{p == child' u l})
+  (decreases n)
+  =
+  if n = 0 then
+    let (lbl, p) = List.Tot.hd u in
+    let pkg = match p with Node p _ -> p | Leaf p -> p in
+    let _ = assert(child' u lbl == pkg) in
+    (| lbl, pkg |)
+  else 
+    let u' = List.Tot.tl u in
+    let (|lbl, p|) = nth_child u' (n-1) in
+    // FIXME(adl): label disjointness, see disjoint_labels in Pkg.Tree
+    let _ = assume(fst (List.Tot.hd u) <> lbl) in
+    let _ = lemma_has_lbl_cons u' (List.Tot.hd u) lbl in
+    (|lbl, p|)
+
+// Given the index i of a KDF instance, we compute
+// the associated virtual idealization table
+let compute_kdf_table (#ideal:iflag) (u:usage ideal) (i:regid{model}) (h:mem)
+  : GTot (kdf_table u i)
+  =
+  let l : children' (b2t ideal) = u in
+  let m = List.Tot.length l in
+  let rec aux (n:nat{n <= m}) : GTot (kdf_table u i) =
+    if n = 0 then
+      DM.create (fun l -> DM.create (fun k -> None <: kdf_value u i l k))
+    else
+      let (| lbl, pkg |) = nth_child l (m - n) in
+      let dt : DT.dt #regid (Pkg?.key (child u lbl)) = pkg.define_table in
+      // The define table is specified by a DependentMap
+      let m = MDM.repr (HS.sel h (DT.ideal dt)) in
+      // Filter for entries derived from i with label lbl
+      let m' = DM.restrict (derived_from u i lbl) m in
+      // Re-index table by context
+      let m'' = DM.rename m' (reindex u i lbl) in
+      // Coerce the type of instances to the type of KDF tables
+      let m''' = DM.map (coerce_reindex u i lbl) m'' in
+      DM.upd (aux (n-1)) lbl m'''
+    in
+  aux m
+
+(*
 type empty (#ideal:iflag) (#u:usage ideal) (#i:regid) (k:secret u i) (h:mem) =
   (if Model.is_safe k then HS.sel h (Model.ideal k) == MDM.empty else True)
 
 type live (#ideal:iflag) (#u:usage ideal) (#i:regid) (k:secret u i) (h:mem) =
   Model.is_safe k ==> h `HS.contains` (Model.ideal k)
-
-// FIXME(adl) missing the case honest_idh ctx
+*)
 
 // The KDF invariant specifies that when the KDF is ideal,
 // its table contains entries that are defined if, and only if,
@@ -173,8 +282,9 @@ type kdf_invariant_wit (#ideal:iflag) (#u:usage ideal) (#i:regid)
   let dt = DT.ideal pkg'.define_table in
   DT.live #_ #(Pkg?.key pkg') dt h /\
   (if Model.is_safe k then (
-    h `HS.contains` (Model.ideal k) /\ // KDF table is live
-    MDM.sel (sel h (Model.ideal k)) (Domain lbl ctx) == MDM.sel (sel h dt) i'
+    True
+//    h `HS.contains` (Model.ideal k) // KDF table is live
+//    MDM.sel (sel h (Model.ideal k)) (Domain lbl ctx) == MDM.sel (sel h dt) i'
   ) else
    begin
     let (| a, raw |) = Model.real k in
@@ -191,7 +301,7 @@ type kdf_invariant_wit (#ideal:iflag) (#u:usage ideal) (#i:regid)
 let lemma_kdf_invariant_init_wit (#ideal:iflag) (#u:usage ideal) (#i:regid)
   (k:secret u i) (h:mem) (lbl:label {u `has_lbl` lbl})
   (ctx:context{~(honest_idh ctx) /\ wellformed_derive i lbl ctx /\ registered (derive i lbl ctx)})
-  : Lemma (requires empty k h /\ live k h /\
+  : Lemma (requires // empty k h /\ live k h /\
     DT.live (child u lbl).define_table h /\
     DT.empty (child u lbl).define_table h)
   (ensures kdf_invariant_wit k h lbl ctx)
@@ -209,28 +319,19 @@ type kdf_invariant (#ideal:iflag) (#u:usage ideal) (#i:regid) (k:secret u i) (h:
     kdf_invariant_wit k h lbl ctx)
   else True)
 
-#push-options "--max_fuel 1 --max_ifuel 1"
-
 // The union of all the define table of the children of the KDF
-let rec children_fp (#ideal:iflag) (u:usage ideal) : GTot M.loc =
-  if model then
-    let l : children' (b2t ideal) = u in
-    match l with
-    | [] -> M.loc_none
-    | (lbl, _)::t ->
-      M.loc_union (DT.loc (child u lbl).define_table) (children_fp #ideal t)
-  else M.loc_none
-
-let loc (#ideal:iflag) (#u:usage ideal) (#i:regid) (k:secret u i) =
-  if Model.is_safe k then M.loc_mreference (Model.ideal k) else M.loc_none
+let rec children_fp (#p:Type) (u:children' p) : GTot M.loc =
+  match u with
+  | [] -> M.loc_none
+  | (lbl, _)::t ->
+    M.loc_union (DT.loc (child' u lbl).define_table) (children_fp #p t)
 
 // The footprint of the KDF invariant is:
-//  - 1. its idealized KDF table
+//  - DEPRECATED 1. its idealized KDF table
 //  - 2. the define table of all children
 let kdf_footprint (#ideal:iflag) (#u:usage ideal) (#i:regid) (k:secret u i)
-  : GTot M.loc
-  =
-  M.loc_union (loc k) (children_fp u)
+  : GTot M.loc =
+  if model then children_fp (u <: children' (b2t ideal)) else M.loc_none
 
 // Intuitively, if a location is disjoint from the KDF footprint,
 // it is disjoint from the define table of all children. The proof
@@ -244,21 +345,19 @@ let lemma_kdf_footprint_disjoint_wit (#ideal:iflag) (#u:usage ideal)
   (ensures M.loc_disjoint l (DT.loc (child u lbl).define_table))
   =
   if model then
-    let rec aux (#ideal:iflag) (u:usage ideal) (lbl:label{model /\ u `has_lbl` lbl})
+    let rec aux (#p:Type0) (u:children' p) (lbl:label{u `has_lbl'` lbl})
       : Lemma
         (requires M.loc_disjoint l (children_fp u))
-        (ensures M.loc_disjoint l (DT.loc (child u lbl).define_table))
+        (ensures M.loc_disjoint l (DT.loc (child' u lbl).define_table))
       =
-      if model then
-        let c : children' (b2t ideal) = u in
-        match c with
-        | [] -> assert_norm(u `find_lbl` lbl == None)
-        | (lbl', _) :: t ->
-          if lbl = lbl' then ()
-          else aux #ideal t lbl
-      else ()
+      match u with
+      | [] -> assert_norm(u `find_lbl'` lbl == None)
+      | (lbl', _) :: t ->
+        if lbl = lbl' then ()
+        else aux t lbl
       in
-    aux u lbl
+    aux (u <: children' (b2t ideal)) lbl
+  else ()
 
 // Trivial lemma but useful to drive stateful proofs by introducing
 // the expected goals and the right patterns
@@ -267,11 +366,9 @@ private let lemma_unchanged #a #rel (r:mreference a rel) h0 l h1 : Lemma
     M.loc_disjoint l (M.loc_mreference r))
   (ensures HS.sel h0 r == HS.sel h1 r) = ()
 
-#pop-options
-
 let lemma_kdf_invariant_init (#ideal:iflag) (#u:usage ideal)
   (#i:regid) (k:secret u i) (h:mem)
-  : Lemma (requires empty k h /\ live k h /\
+  : Lemma (requires //empty k h /\ live k h /\
     (forall (l:label{u `has_lbl` l}).
       DT.live (child u l).define_table h /\
       DT.empty (child u l).define_table h))
@@ -303,11 +400,13 @@ let kdf_invariant_framing (#ideal:iflag) (#u:usage ideal)
       lemma_honest_parent_impl i lbl ctx;
       let pkg' = child u lbl in
       let dt : DT.table (Pkg?.key pkg') = DT.ideal pkg'.define_table in
-      assert_norm(DT.live pkg'.define_table h0 == (model ==> h0 `HS.contains` dt));
-      assert_norm(DT.loc pkg'.define_table == (if model then M.loc_mreference dt else M.loc_none));
+      assert_norm(DT.live pkg'.define_table h0 ==
+        (model ==> h0 `HS.contains` dt));
+      assert_norm(DT.loc pkg'.define_table ==
+        (if model then M.loc_mreference dt else M.loc_none));
       lemma_kdf_footprint_disjoint_wit k lbl ctx l;
-      lemma_unchanged dt h0 l h1; // Trivial, but helps the proof
-      if Model.is_safe k then lemma_unchanged (Model.ideal k) h0 l h1
+      lemma_unchanged dt h0 l h1 // Trivial, but helps the proof
+//      if Model.is_safe k then lemma_unchanged (Model.ideal k) h0 l h1
     in
     FStar.Classical.forall_intro_2 prove_on_witness
 
@@ -344,26 +443,6 @@ let coerce #ideal u i a repr =
   lemma_kdf_invariant_init k h1;
   k
 
-/// NS:
-/// MDM.alloc is a stateful function with all implicit arguments
-/// F* will refuse to instantiate all those arguments, since implicit
-/// instantiation in F* should never result in an effect.
-///
-/// Stateful functions always take at least 1 concrete argument.
-///
-/// I added a unit here
-///
-/// CF: Ok; I did not know. Is it a style bug in FStar.Monotonic.Map ?
-let alloc #a #b #inv (r: erid):
-  ST (MDM.t r a b inv)
-    (requires (fun h ->
-      inv (MDM.empty_partial_dependent_map #a #b) /\
-      witnessed (region_contains_pred r) ))
-    (ensures (fun h0 x h1 ->
-      inv (MDM.empty_partial_dependent_map #a #b) /\
-      ralloc_post r (MDM.empty #a #b) h0 x h1))
-  = MDM.alloc #a #b #inv #r ()
-
 noextract
 val create:
   #ideal: iflag ->
@@ -373,8 +452,11 @@ val create:
   ST (secret u i)
   (requires fun h0 -> model)
   (ensures fun h0 k h1 -> modifies_none h0 h1
-    /\ fresh_regions (kdf_footprint k) h0 h1
-    /\ kdf_post a k h1 /\ local_kdf_invariant k h1)
+//    /\ fresh_regions (kdf_footprint k) h0 h1
+//    /\ kdf_post a k h1
+     /\ kdf_invariant k h1)
+
+#set-options "--admit_smt_queries true"
 
 noextract
 let create #ideal u i a =
@@ -383,6 +465,7 @@ let create #ideal u i a =
   let h1 = get() in
   if ideal && honest then
    begin
+     (*
     assert(safe u i);
     let r : subrgn kdf_tables_region = new_region kdf_tables_region in
     let h2 = get() in
@@ -393,12 +476,11 @@ let create #ideal u i a =
     assume(kdf_footprint k == Set.singleton r);
     assume(local_kdf_invariant k h3);
     assert(fresh_regions (kdf_footprint k) h0 h3);
-    k
+    k *) Model.mk_ideal () <: secret u i
    end
   else
    begin
     let k = Model.mk_real (| a, sample (secret_len a) |) in
-    assume(local_kdf_invariant k h1);
     k
    end
 
@@ -412,14 +494,12 @@ let local_kdf_pkg (ideal:iflag) (u:usage ideal) : local_pkg ii =
   (LocalPkg
     (secret u)
     info0
+    index_info
     (fun #_ a -> secret_len a)
     (b2t ideal)
-    (kdf_shared_footprint u)
-    (kdf_footprint #ideal #u)
-    (local_kdf_invariant #ideal #u)
-    (local_kdf_invariant_framing #ideal #u)
-    (kdf_post #ideal #u)
-    (kdf_post_framing #ideal #u)
+    (fun #_ _ -> M.loc_none)
+    (kdf_invariant #ideal #u)
+    (kdf_invariant_framing #ideal #u)
     (create #ideal u)
     (coerceT #ideal u)
     (coerce #ideal u))
@@ -428,28 +508,11 @@ noextract
 let pp (ideal:iflag) (u:usage ideal) : ST (pkg ii)
   (requires fun h0 -> True)
   (ensures fun h0 p h1 ->
-     modifies_mem_table p.define_table h0 h1 /\
-     p.package_invariant h1)
+    locally_packaged p (local_kdf_pkg ideal u) /\
+    p.package_invariant h1 /\
+    fresh_loc (DT.loc p.define_table) h0 h1)
   =
   memoization_ST #ii (local_kdf_pkg ideal u)
-
-/// 17-11-30 experiment, testing package trees on a simple case: AEAD
-/// keying and forward re-keying; still unclear how to traverse the
-/// packaging.
-
-
-/// Global, generic invariant, to be rooted at the PSK
-/// (do we need some "static index"?)
-
-// node footprints already recursively collect their children's footprints
-let tree_footprint (#p:Type0) (x:tree' p) h : GTot rset =
-  match x with
-  | Leaf p -> Pkg?.footprint p h
-  | Node p c -> Pkg?.footprint p h
-
-// WIP: footprint_kdf includes the define tables of children, but not the package footprints
-//    rset_union (Pkg?.footprint p h)
-//      (List.Tot.fold_left (fun s p -> rset_union s (Pkg?.footprint p h)) c Set.empty)
 
 // library??
 noextract
@@ -458,22 +521,7 @@ let rec list_forall f l = match l with
     | [] -> True
     | hd::tl -> f hd /\ list_forall f tl
 
-noextract
-val disjoint_children: mem -> #p:Type0 -> children' p -> Type0
-let rec disjoint_children h #p x =
-  match x with
-  | [] -> True
-  | (l0, x0) :: tail -> list_forall (fun (l1, x1) -> tree_footprint #p x0 h `Set.disjoint` tree_footprint #p x1 h) tail
-
-noextract
-let rec children_forall
-  (#p:Type0) (lxs: children' p)
-  (f: (x:tree' p{depth x <= children_depth lxs} -> Type0)): Type0
-=
-  match lxs with
-  | [] -> True
-  | (_,x)::tl -> f x /\ children_forall tl f
-
+(*
 noextract
 let rec tree_invariant' (#pp:Type0) (x:tree' pp) (h:mem)
   : Tot Type0 (decreases %[depth x]) =
@@ -495,6 +543,7 @@ let tree_invariant_frame #p (t:tree p) (h0:mem) (h1:mem)
   : Lemma (requires tree_invariant t h0 /\ (modifies_none h0 h1 \/ modifies_one tls_honest_region h0 h1))
           (ensures tree_invariant t h1)
   = admit()
+*)
 
 // TODO 17-12-01 we need an hypothesis that captures that p is in the tree, e.g. only deal with the case where p is a child.
 
@@ -524,29 +573,21 @@ let u_of_t (#ideal:iflag) (t:tree (b2t ideal){kdf_subtree ideal t}) : usage idea
 type modifies_derive (#ideal:iflag) (#u:usage ideal) (#i:regid) (k:secret u i)
   (lbl:label) (ctx:context {wellformed_derive i lbl ctx}) (h0:mem) (h1:mem) =
   (if u `has_lbl` lbl then
-    let modset = Set.singleton tls_define_region in
-    let modset = Set.union modset (Set.singleton tls_honest_region) in
-    let modset =
-      if Model.is_safe k then
-        let KDF_table r _ = Model.ideal k () in Set.union modset (Set.singleton r)
-      else modset in
+    let lhonest = M.loc_region_only true tls_honest_region in
     let utable = (child u lbl).define_table in
-    modifies modset h0 h1
-    /\ HS.modifies_ref tls_define_region (Set.singleton (mem_addr (itable utable))) h0 h1
-  else modifies_none h0 h1) // FIXME concrete state
+    M.modifies (M.loc_union utable lhonest) h0 h1
+  else M.modifies M.loc_none h0 h1)
 
-unfold type rid = i:(Idx?.t ii){(Idx?.registered ii) i}
-
-(** Ugly coercion, required because the type equality is proved by normalization **)
 noextract
-private let _mem_coerce (#t0:eqtype) (#t1:t0 -> Type) (dt:mem_table t1) (#ideal:iflag) (t:tree (b2t ideal){kdf_subtree ideal t})
-  : Pure (mem_table (secret (u_of_t t)))
+private let _mem_coerce (#t0:eqtype) (#t1:t0 -> Type)
+  (dt:DT.dt t1) (#ideal:iflag) (t:tree (b2t ideal){kdf_subtree ideal t})
+  : Pure (DT.dt (secret (u_of_t t)))
   (requires model /\ t0 == rid /\ t1 == secret (u_of_t t))
   (ensures fun dt' -> True) = assert_norm(rid == regid); dt
 
 inline_for_extraction noextract
 let kdf_dt (#ideal:iflag) (t:tree (b2t ideal){kdf_subtree ideal t})
-  : mem_table (secret (u_of_t t)) =
+  : DT.dt (secret (u_of_t t)) =
   if model then
     let Node p u = itree t in
     _mem_coerce (Pkg?.define_table p) t
@@ -559,10 +600,8 @@ let compatible_packages (lp:local_pkg ii) (p:pkg ii) =
   Pkg?.key p == LocalPkg?.key lp /\
   p == memoization lp p.define_table
 
-/// The well-formedness condition on the derived label (opaque from
-/// the viewpoint of the KDF) enforces
-///
-#set-options "--query_stats"
+// The well-formedness condition on the derived label (opaque from
+// the viewpoint of the KDF) enforces
 noextract inline_for_extraction
 val derive:
   #ideal: iflag ->
@@ -579,18 +618,19 @@ val derive:
     (LocalPkg?.len child_pkg) a' == EverCrypt.Hash.tagLen (get_info k).ha /\
     ((u_of_t t) `has_lbl` lbl ==>
       compatible_packages child_pkg (child (u_of_t t) lbl)) /\
-    mem_defined (kdf_dt t) i /\
-    tree_invariant t h0)
+    DT.defined (kdf_dt t) i /\
+    tree_inv t h0)
   (ensures fun h0 (| () , r |) h1 ->
     modifies_derive k lbl ctx h0 h1 /\
-    tree_invariant t h1 /\
+    tree_inv t h1 /\
     (~(safe (u_of_t t) i) ==> (
       let (| a, raw |) = Model.real k in
       let lb = Bytes.bytes_of_string lbl in
       let len' = LocalPkg?.len child_pkg a' in
       r == (LocalPkg?.coerceT child_pkg) (derive i lbl ctx) a'
-      (HKDF.expand_spec #a.ha raw lb len'))) /\
-    (model ==> (LocalPkg?.post child_pkg) a' r h1))
+      (HKDF.expand_spec #a.ha raw lb len')))
+    )
+//    /\ (model ==> (LocalPkg?.post child_pkg) a' r h1))
 
 noextract inline_for_extraction
 let derive #ideal #t #i k lbl ctx child_pkg a' =
@@ -600,11 +640,12 @@ let derive #ideal #t #i k lbl ctx child_pkg a' =
   let honest = get_honesty i in
   let i', honest' = register_derive i lbl ctx in
   let h1 = get() in
-  tree_invariant_frame t h0 h1;
+//  tree_invariant_frame t h0 h1;
   lemma_corrupt_invariant i lbl ctx;
 
   if model then
    begin
+   (*
     assume false; // Ideal branch is WIP, working on extraction now
     let _ = // Ghost section
       let log = itable dt in
@@ -639,6 +680,8 @@ let derive #ideal #t #i k lbl ctx child_pkg a' =
       let dk = (LocalPkg?.coerce child_pkg) i' a' raw in
       (| (), dk |)
      end
+    *)
+    admit()
    end
   else
    begin
@@ -649,7 +692,5 @@ let derive #ideal #t #i k lbl ctx child_pkg a' =
     let raw = HKDF.expand #(a.ha) key lb len' in
     let dk = (LocalPkg?.coerce child_pkg) i' a' raw in
     let h2 = get() in
-//    assert(modifies_none h1 h2);
-    assume(modifies_derive k lbl ctx h0 h2); // FIXME stronger spec for Pkg.coerce?
     (| (), dk |)
    end

--- a/src/tls/KDF.fst
+++ b/src/tls/KDF.fst
@@ -288,7 +288,7 @@ let kdf_invariant_framing (#ideal:iflag) (#u:usage ideal)
       : Lemma (kdf_invariant_wit k h1 lbl ctx)
       =
       let i' : regid = derive i lbl ctx in
-      lemma_honest_parent i lbl ctx;
+      lemma_honest_parent_impl i lbl ctx;
       let pkg' = child u lbl in
       let dt : DT.table (Pkg?.key pkg') = DT.ideal pkg'.define_table in
       assert_norm(DT.live pkg'.define_table h0 == (model ==> h0 `HS.contains` dt));
@@ -308,6 +308,7 @@ val coerceT:
   a: info0 i ->
   repr: lbytes32 (secret_len a) ->
   GTot (secret u i)
+
 let coerceT #ideal u i a repr =
   Model.mk_real (| a, repr |)
 
@@ -325,12 +326,12 @@ val coerce:
     kdf_invariant k h1)
 
 let coerce #ideal u i a repr =
+  let h0 = get () in
   let k = Model.mk_real (| a, repr |) in
-  admit()
-  
-// WIP stronger packaging
-//  (if model then assume(local_kdf_invariant k h1));
-//  k
+  let h1 = get () in
+  assume false;
+  lemma_kdf_invariant_init k h1;
+  k
 
 /// NS:
 /// MDM.alloc is a stateful function with all implicit arguments

--- a/src/tls/KDF.fst
+++ b/src/tls/KDF.fst
@@ -127,6 +127,14 @@ let lemma_honest_parent i lbl ctx =
     lemma_witnessed_impl (MDM.contains log (derive i lbl ctx) true) (MDM.contains log i true)
   else ()
 
+let lemma_honest_parent_impl (i:regid) (lbl:label) (ctx:context)
+  : Lemma (requires wellformed_derive i lbl ctx /\ 
+            registered (derive i lbl ctx) /\ 
+            ~(honest_idh ctx))
+	  (ensures honest (derive i lbl ctx) ==> honest i)
+  = FStar.Classical.impl_intro_gen #(honest (derive i lbl ctx)) #(fun _ -> honest i)
+    (fun (u:squash (honest (derive i lbl ctx))) -> lemma_honest_parent i lbl ctx)
+
 inline_for_extraction
 let get_info (#ideal:iflag) (#u:usage ideal) (#i:regid) (k:secret u i) =
   if Model.is_safe k then index_info i else dfst (Model.real k)
@@ -150,7 +158,7 @@ type kdf_invariant_wit (#ideal:iflag) (#u:usage ideal) (#i:regid)
   (ctx:context{~(honest_idh ctx) /\ wellformed_derive i lbl ctx /\ registered (derive i lbl ctx)})
   =
   (let i' : regid = derive i lbl ctx in
-  lemma_honest_parent i lbl ctx;
+  lemma_honest_parent_impl i lbl ctx;
   let pkg' = child u lbl in
   let dt = DT.ideal pkg'.define_table in
   DT.live #_ #(Pkg?.key pkg') dt h /\
@@ -318,6 +326,7 @@ val coerce:
 
 let coerce #ideal u i a repr =
   let k = Model.mk_real (| a, repr |) in
+  admit()
   
 // WIP stronger packaging
 //  (if model then assume(local_kdf_invariant k h1));

--- a/src/tls/Mem.fst
+++ b/src/tls/Mem.fst
@@ -162,42 +162,6 @@ let ssa #a =
     | _ -> False in
   f
 
-(* ADL: deprecated in favor of loc
-
-// We use this instead of Set.set rgn because otherwise subtyping fails in pkg.
-// The second line embeds the definition of rgn because of the unification bug
-//
-// An rset can be thought of as a set of disjoint subtrees in the region tree
-// rset are downward closed - if r is in s and r' extends r then r' is in s too
-// this allows us to prove disjointness with negation of set membership.
-
-type rset = s:Set.set HS.rid{
-  (forall (r1:HS.rid).{:pattern (Set.mem r1 s)} (Set.mem r1 s ==> 
-     r1 <> HS.root /\
-     (is_tls_rgn r1 ==> r1 `HS.extends` tls_tables_region) /\
-     (forall (r':HS.rid).{:pattern (r' `HS.includes` r1)} r' `is_below` r1 ==> Set.mem r' s)))}
-
-let rset_empty (): GTot rset = Set.empty
-let rset_union (s1:rset) (s2:rset): GTot rset = let r = (Set.union s1 s2) in r
-
-/// SZ: This is the strongest lemma that is provable
-/// Note that this old stronger version doesn't hold:
-///
-/// let lemma_rset_disjoint (s:rset) (r:HS.rid) (r':HS.rid)
-///  : Lemma (requires ~(Set.mem r s) /\ (Set.mem r' s))
-///          (ensures  r `HS.disjoint` r')
-
-let lemma_rset_disjoint (s:rset) (r:HS.rid) (r':HS.rid)
-  : Lemma (requires Set.mem r s /\ ~(Set.mem r' s) /\ r' `is_below` r)
-          (ensures  r `HS.disjoint` r')
-  = ()
-
-// We get from the definition of rset that define_region and tls_honest_region are disjoint
-let lemma_define_tls_honest_regions (s:rset)
-  : Lemma (~(Set.mem tls_define_region s) /\ ~(Set.mem tls_honest_region s))
-  = ()
-*)
-
 let loc_in (l: M.loc) (h: HS.mem) =
   M.loc_not_unused_in h `M.loc_includes` l
 

--- a/src/tls/Mem.fst
+++ b/src/tls/Mem.fst
@@ -212,3 +212,6 @@ let fresh_is_disjoint (old_loc:M.loc) (new_loc:M.loc)
   (requires (fresh_loc new_loc h0 h1 /\ old_loc `loc_in` h0))
   (ensures (M.loc_disjoint old_loc new_loc))
   = ()
+
+type sub_loc (parent:M.loc) =
+  l:M.loc{if model then M.loc_includes parent l else l == M.loc_none}

--- a/src/tls/Mem.fst
+++ b/src/tls/Mem.fst
@@ -44,6 +44,7 @@ open LowStar.BufferOps
 // [b *= v; !*b] when i = 0 for even nicer C syntax
 
 module B = LowStar.Buffer // rather than bytes
+module M = LowStar.Modifies
 
 (* trying out  syntax 
 open FStar.Integers 
@@ -74,9 +75,6 @@ module MDM = FStar.Monotonic.DependentMap
 
 inline_for_extraction 
 let model = Flags.model 
-
-// disjointness of regions; otherwise use LowStar.Buffer.loc_disjoint 
-let disjoint = HS.disjoint
 
 /// 18-01-04 We need to explicitly choose between using colors and
 /// using hierarchy & transitivity.
@@ -164,38 +162,7 @@ let ssa #a =
     | _ -> False in
   f
 
-
-(* An earlier variant of the code below, to be deleted 
-
-// FIXME(adl) can't write Set.set rgn because unification fails in pkg!!
-// FIXME(adl) overcomplicated type because of transitive modifications.
-// An rset can be thought of as a set of disjoint subtrees in the region tree
-// the second line embeds the definition of rgn because of the unification bug
-type rset = s:Set.set HS.rid{
-  (forall (r1:rgn) (r2:rgn).{:pattern (Set.mem r1 s /\ Set.mem r2 s)} (Set.mem r1 s /\ Set.mem r2 s) ==> (r1 == r2 \/ HS.disjoint r1 r2)) /\
-  (forall (r1:rgn). (Set.mem r1 s ==>
-     r1<>HS.root /\
-     (is_tls_rgn r1 ==> r1 `HS.extends` tls_tables_region) /\
-     (forall (s:HS.rid).{:pattern is_eternal_region s} s `is_above` r1 ==> is_eternal_region s)))}
-
-// We get from the definition of rset that define_region and tls_honest_region are disjoint
-let lemma_define_tls_honest_regions (s:rset)
-  : Lemma (~(Set.mem tls_define_region s) /\ ~(Set.mem tls_honest_region s))
-  = ()
-
-//  if Set.mem tls_define_region s then
-//    assert(tls_define_region `HS.extends` tls_)
-
-type disjoint_rset (s1:rset) (s2:rset) =
-  Set.disjoint s1 s2 /\
-  (forall (r1:rgn) (r2:rgn).{:pattern (Set.mem r1 s1 /\ Set.mem r2 s2)}
-   (Set.mem r1 s1 /\ Set.mem r2 s2) ==> HS.disjoint r1 r2)
-
-assume val lemma_disjoint_ancestors:
-  r1:rgn -> r2:rgn -> p1:rgn{r1 `is_below` p1} -> p2:rgn{r2 `is_below` p2}
-  -> Lemma (requires p1 <> p2) (ensures HS.disjoint r1 r2 /\ r1 <> r2)
-*)
-
+(* ADL: deprecated in favor of loc
 
 // We use this instead of Set.set rgn because otherwise subtyping fails in pkg.
 // The second line embeds the definition of rgn because of the unification bug
@@ -229,54 +196,19 @@ let lemma_rset_disjoint (s:rset) (r:HS.rid) (r':HS.rid)
 let lemma_define_tls_honest_regions (s:rset)
   : Lemma (~(Set.mem tls_define_region s) /\ ~(Set.mem tls_honest_region s))
   = ()
+*)
 
-//18-01-04 Consider moving the rest to a separate library
-type trivial_inv #it #vt: DM.t it (MDM.opt vt) -> Tot Type = fun _ -> True
-type i_mem_table (#it:eqtype) (vt:it -> Type) =
-  MDM.t tls_define_region it vt trivial_inv
-type mem_table (#it:eqtype) (vt:it -> Type) =
-  (if model then i_mem_table vt else unit)
+let loc_in (l: M.loc) (h: HS.mem) =
+  M.loc_not_unused_in h `M.loc_includes` l
 
-noextract inline_for_extraction
-let itable (#it:eqtype) (#vt:it -> Type) (t:mem_table vt)
-  : Pure (i_mem_table vt) (requires model) (ensures fun _ -> True) = t
+let loc_unused_in (l: M.loc) (h: HS.mem) =
+  M.loc_unused_in h `M.loc_includes` l
 
-let mem_addr (#it:eqtype) (#vt:it -> Type) (t:i_mem_table vt): GTot nat = HS.as_addr t
+let fresh_loc (l: M.loc) (h0 h1: HS.mem) =
+  loc_unused_in l h0 /\ loc_in l h1
 
-type mem_fresh (#it:eqtype) (#vt:it -> Type) (t:mem_table vt) (i:it) (h:mem) =
-  model ==> MDM.fresh (itable t) i h
-type mem_defined (#it:eqtype) (#vt:it -> Type) (t:mem_table vt) (i:it) =
-  model ==> witnessed (MDM.defined (itable t) i)
-type mem_update (#it:eqtype) (#vt:it -> Type) (t:mem_table vt) (i:it) (v:vt i) (h0 h1:mem) =
-  mem_defined t i /\
-  (model ==> HS.sel h1 (itable t) == MDM.upd (HS.sel h0 (itable t)) i v)
-
-type mem_stable (#it:eqtype) (#vt:it -> Type) (t:mem_table vt) (h0 h1:mem) =
-  model ==> HS.sel h0 (itable t) == HS.sel h1 (itable t)
-type mem_empty (#it:eqtype) (#vt:it -> Type) (t:mem_table vt) (h1:mem) =
-  model ==> HS.sel h1 (itable t) == MDM.empty
-
-type modifies_mem_table (#it:eqtype) (#vt:it -> Type) (t:mem_table vt) (h0 h1:mem) =
-  (if model then
-     (modifies_one tls_define_region h0 h1 /\
-     HS.modifies_ref tls_define_region (Set.singleton (mem_addr (itable t))) h0 h1)
-  else modifies_none h0 h1)
-type mem_disjoint (#it:eqtype) (#vt:it -> Type) (t:mem_table vt)
-  (#it':eqtype) (#vt':it' -> Type) (t':mem_table vt') =
-  model ==> mem_addr (itable t) <> mem_addr (itable t')
-
-let mem_alloc (#it:eqtype) (vt:it -> Type) : ST (mem_table vt)
-  (requires fun h0 -> True)
-  (ensures fun h0 t h1 -> modifies_mem_table t h0 h1 /\ mem_empty t h1)
-  =
-  if model then (MDM.alloc #it #vt #trivial_inv #tls_define_region ())  else ()
-
-type mem_contains (#it:eqtype) (#vt:it -> Type) (t:mem_table vt) (h:mem) =
-  model ==> h `contains` (itable t)
-let lemma_mem_disjoint_stable (#it:eqtype) (#vt:it -> Type) (t:mem_table vt)
-  (#it':eqtype) (#vt':it' -> Type) (t':mem_table vt') (h0:mem) (h1:mem) : Lemma
-  (requires modifies_mem_table t h0 h1 /\ mem_disjoint t t' /\ mem_contains t h0 /\ mem_contains t' h0)
-  (ensures mem_stable t' h0 h1) = ()
-let lemma_mem_frame (#it:eqtype) (#vt:it -> Type) (t:mem_table vt) (h0:mem) (r:HS.rid) (h1:mem) : Lemma
-  (requires modifies_one r h0 h1 /\ tls_define_region `HS.disjoint` r /\ mem_contains t h0)
-  (ensures mem_stable t h0 h1) = ()
+let fresh_is_disjoint (old_loc:M.loc) (new_loc:M.loc)
+  (h0 h1:HS.mem) : Lemma
+  (requires (fresh_loc new_loc h0 h1 /\ old_loc `loc_in` h0))
+  (ensures (M.loc_disjoint old_loc new_loc))
+  = ()

--- a/src/tls/Model.CRF.fst
+++ b/src/tls/Model.CRF.fst
@@ -3,6 +3,8 @@ module Model.CRF
 
 /// This module should not be extracted
 
+open Spec.Hash.Definitions
+open EverCrypt.Hash
 open EverCrypt.Hash.Incremental // only for the specs (renamings)
 
 #set-options "--max_fuel 0 --max_ifuel 0"
@@ -40,9 +42,7 @@ private type domain (r:range) =
     Seq.length b < max_input_length a /\
     h a b = t}
 
-private let inv (f:MDM.partial_dependent_map range domain) = True // a bit overkill?
-
-private let table : MDM.t tls_tables_region range domain inv = MDM.alloc()
+private let table : MDM.t tls_tables_region range domain (fun _ -> True) = MDM.alloc()
 
 // witnessing that we hashed this particular content (for collision detection)
 // to be replaced by a witness of inclusion in a global table of all hash computations.

--- a/src/tls/PSK.fst
+++ b/src/tls/PSK.fst
@@ -9,34 +9,21 @@ open TLSConstants
 
 module DM = FStar.DependentMap
 module MDM = FStar.Monotonic.DependentMap
+module DT = DefineTable
 module HS = FStar.HyperStack
 module ST = FStar.HyperStack.ST
 
-// Has been moved to TLSConstants as it appears in config for ticket callbacks
+(* Main RFC data types for PSKs *)
+include Parsers.PskIdentity
+include Parsers.PskIdentity_identity
+include Parsers.OfferedPsks
+
+// The type of PSK identifiers (labels used in TLS messages)
+type pskName = pskIdentity_identity
+
+// The information associated with a PSK, i.e. time created,
+// usage (PSK+DHE or PSK only), hash, and AEAD (for 0-RTT)
 type pskInfo = TLSConstants.pskInfo
-
-// SESSION TICKET DATABASE (TLS 1.3)
-// Note that the associated PSK are stored in the PSK table defined below in this file
-let hostname : eqtype = string
-
-let tlabel (h:hostname) = bytes
-
-noextract
-private let tregion:rgn = new_region tls_tables_region
-private let tickets : MDM.t tregion hostname tlabel (fun _ -> True) =
-  MDM.alloc ()
-
-let lookup (h:hostname) = MDM.lookup tickets h
-let extend (h:hostname) (t:tlabel h) = MDM.extend tickets h t
-
-// SESSION TICKET DATABASE (TLS 1.2)
-// Note that this table also stores the master secret
-type session12 (tid:bytes) = protocolVersion * cipherSuite * ems:bool * ms:bytes
-private let sessions12 : MDM.t tregion bytes session12 (fun _ -> True) =
-  MDM.alloc ()
-
-let s12_lookup (tid:bytes) = MDM.lookup sessions12 tid
-let s12_extend (tid:bytes) (s:session12 tid) = MDM.extend sessions12 tid s
 
 // *** PSK ***
 

--- a/src/tls/ParsersAux.Binders.Aux.fst
+++ b/src/tls/ParsersAux.Binders.Aux.fst
@@ -71,9 +71,9 @@ let serialize_clientHello_eq
 = LP.serialize_synth_eq _ CH.synth_clientHello CH.clientHello'_serializer CH.synth_clientHello_recip () c;
   LP.serialize_nondep_then_eq
     ((Parsers.ProtocolVersion.protocolVersion_serializer `LP.serialize_nondep_then` Parsers.Random.random_serializer) `LP.serialize_nondep_then` (Parsers.SessionID.sessionID_serializer `LP.serialize_nondep_then` CH.clientHello_cipher_suites_serializer))
-    (CH.clientHello_compression_method_serializer `LP.serialize_nondep_then` CHEs.clientHelloExtensions_serializer)
+    (CH.clientHello_compression_methods_serializer `LP.serialize_nondep_then` CHEs.clientHelloExtensions_serializer)
     (((c.CH.version, c.CH.random), (c.CH.session_id, c.CH.cipher_suites)),
-    (c.CH.compression_method, c.CH.extensions));
+    (c.CH.compression_methods, c.CH.extensions));
   LP.serialize_nondep_then_eq
     (Parsers.ProtocolVersion.protocolVersion_serializer `LP.serialize_nondep_then` Parsers.Random.random_serializer)
     (Parsers.SessionID.sessionID_serializer `LP.serialize_nondep_then` CH.clientHello_cipher_suites_serializer)
@@ -87,9 +87,9 @@ let serialize_clientHello_eq
     CH.clientHello_cipher_suites_serializer
     (c.CH.session_id, c.CH.cipher_suites);
   LP.serialize_nondep_then_eq
-    CH.clientHello_compression_method_serializer
+    CH.clientHello_compression_methods_serializer
     CHEs.clientHelloExtensions_serializer
-    (c.CH.compression_method, c.CH.extensions)
+    (c.CH.compression_methods, c.CH.extensions)
 
 let serialize_handshake_m_client_hello_eq
   c

--- a/src/tls/ParsersAux.Binders.Aux.fsti
+++ b/src/tls/ParsersAux.Binders.Aux.fsti
@@ -92,7 +92,7 @@ val serialize_clientHello_eq
    LP.serialize Parsers.Random.random_serializer c.CH.random `Seq.append`
    LP.serialize Parsers.SessionID.sessionID_serializer c.CH.session_id `Seq.append`
    LP.serialize Parsers.ClientHello_cipher_suites.clientHello_cipher_suites_serializer c.CH.cipher_suites  `Seq.append`
-   LP.serialize Parsers.ClientHello_compression_method.clientHello_compression_method_serializer c.CH.compression_method `Seq.append`
+   LP.serialize Parsers.ClientHello_compression_methods.clientHello_compression_methods_serializer c.CH.compression_methods `Seq.append`
    LP.serialize CHEs.clientHelloExtensions_serializer c.CH.extensions
  ))
 
@@ -103,4 +103,3 @@ val serialize_handshake_m_client_hello_eq
    LP.serialize (LP.serialize_bounded_integer 3) (U32.uint_to_t (CH.clientHello_bytesize c))
    `Seq.append`
    LP.serialize CH.clientHello_serializer c)
-

--- a/src/tls/ParsersAux.Binders.fst
+++ b/src/tls/ParsersAux.Binders.fst
@@ -535,7 +535,7 @@ let clientHello_binders_offset
   Parsers.ProtocolVersion.protocolVersion_size32 c.CH.version `U32.add`
   Parsers.Random.random_size32 c.CH.random `U32.add`
   Parsers.SessionID.sessionID_size32 c.CH.session_id `U32.add`
-  Parsers.ClientHello_cipher_suites.clientHello_cipher_suites_size32 c.CH.cipher_suites `U32.add` Parsers.ClientHello_compression_method.clientHello_compression_method_size32 c.CH.compression_method `U32.add`
+  Parsers.ClientHello_cipher_suites.clientHello_cipher_suites_size32 c.CH.cipher_suites `U32.add` Parsers.ClientHello_compression_methods.clientHello_compression_methods_size32 c.CH.compression_methods `U32.add`
   clientHelloExtensions_binders_offset c.CH.extensions
 
 #push-options "--z3rlimit 16"
@@ -566,7 +566,7 @@ let clientHello_binders_pos
   let pos2 = LP.jump_serializer Parsers.Random.random_serializer Parsers.Random.random_jumper sl pos1 (Ghost.hide (Ghost.reveal x).CH.random) in
   let pos3 = LP.jump_serializer Parsers.SessionID.sessionID_serializer Parsers.SessionID.sessionID_jumper sl pos2 (Ghost.hide (Ghost.reveal x).CH.session_id) in
   let pos4 = LP.jump_serializer CH.clientHello_cipher_suites_serializer CH.clientHello_cipher_suites_jumper sl pos3 (Ghost.hide (Ghost.reveal x).CH.cipher_suites) in
-  let pos5 = LP.jump_serializer CH.clientHello_compression_method_serializer CH.clientHello_compression_method_jumper sl pos4 (Ghost.hide (Ghost.reveal x).CH.compression_method) in
+  let pos5 = LP.jump_serializer CH.clientHello_compression_methods_serializer CH.clientHello_compression_methods_jumper sl pos4 (Ghost.hide (Ghost.reveal x).CH.compression_methods) in
   clientHelloExtensions_binders_pos sl pos5 (Ghost.hide (Ghost.reveal x).CH.extensions)
 
 #pop-options
@@ -596,7 +596,7 @@ let clientHello_set_binders
     c'.CH.random == c.CH.random /\
     c'.CH.session_id == c.CH.session_id /\
     c'.CH.cipher_suites == c.CH.cipher_suites /\
-    c'.CH.compression_method == c.CH.compression_method /\
+    c'.CH.compression_methods == c.CH.compression_methods /\
     Cons? l' /\ (
     let l = c.CH.extensions in
     let e = L.last l in
@@ -612,7 +612,7 @@ let clientHello_set_binders
     CH.random = c.CH.random;
     CH.session_id = c.CH.session_id;
     CH.cipher_suites = c.CH.cipher_suites;
-    CH.compression_method = c.CH.compression_method;
+    CH.compression_methods = c.CH.compression_methods;
     CH.extensions = clientHelloExtensions_set_binders c.CH.extensions b'
   }
 
@@ -652,7 +652,7 @@ let truncate_clientHello_eq_left
    LP.serialize Parsers.Random.random_serializer c.CH.random `Seq.append` (
    LP.serialize Parsers.SessionID.sessionID_serializer c.CH.session_id `Seq.append` (
    LP.serialize Parsers.ClientHello_cipher_suites.clientHello_cipher_suites_serializer c.CH.cipher_suites  `Seq.append` (
-   LP.serialize Parsers.ClientHello_compression_method.clientHello_compression_method_serializer c.CH.compression_method `Seq.append` (
+   LP.serialize Parsers.ClientHello_compression_methods.clientHello_compression_methods_serializer c.CH.compression_methods `Seq.append` (
    truncate_clientHelloExtensions c.CH.extensions
   )))))))
 = serialize_clientHello_eq c
@@ -683,43 +683,43 @@ let truncate_clientHello_inj_binders_bytesize
     (LP.serialize Parsers.Random.random_serializer c1.CH.random `Seq.append` (
       LP.serialize Parsers.SessionID.sessionID_serializer c1.CH.session_id `Seq.append` (
       LP.serialize Parsers.ClientHello_cipher_suites.clientHello_cipher_suites_serializer c1.CH.cipher_suites  `Seq.append` (
-      LP.serialize Parsers.ClientHello_compression_method.clientHello_compression_method_serializer c1.CH.compression_method `Seq.append` (
+      LP.serialize Parsers.ClientHello_compression_methods.clientHello_compression_methods_serializer c1.CH.compression_methods `Seq.append` (
    truncate_clientHelloExtensions c1.CH.extensions
      )))))
      (LP.serialize Parsers.Random.random_serializer c2.CH.random `Seq.append` (
        LP.serialize Parsers.SessionID.sessionID_serializer c2.CH.session_id `Seq.append` (
        LP.serialize Parsers.ClientHello_cipher_suites.clientHello_cipher_suites_serializer c2.CH.cipher_suites  `Seq.append` (
-       LP.serialize Parsers.ClientHello_compression_method.clientHello_compression_method_serializer c2.CH.compression_method `Seq.append` (
+       LP.serialize Parsers.ClientHello_compression_methods.clientHello_compression_methods_serializer c2.CH.compression_methods `Seq.append` (
        truncate_clientHelloExtensions c2.CH.extensions
    )))));
   LP.serialize_strong_prefix Parsers.Random.random_serializer c1.CH.random c2.CH.random
      (LP.serialize Parsers.SessionID.sessionID_serializer c1.CH.session_id `Seq.append` (
       LP.serialize Parsers.ClientHello_cipher_suites.clientHello_cipher_suites_serializer c1.CH.cipher_suites  `Seq.append` (
-      LP.serialize Parsers.ClientHello_compression_method.clientHello_compression_method_serializer c1.CH.compression_method `Seq.append` (
+      LP.serialize Parsers.ClientHello_compression_methods.clientHello_compression_methods_serializer c1.CH.compression_methods `Seq.append` (
    truncate_clientHelloExtensions c1.CH.extensions
      ))))
      (LP.serialize Parsers.SessionID.sessionID_serializer c2.CH.session_id `Seq.append` (
        LP.serialize Parsers.ClientHello_cipher_suites.clientHello_cipher_suites_serializer c2.CH.cipher_suites  `Seq.append` (
-       LP.serialize Parsers.ClientHello_compression_method.clientHello_compression_method_serializer c2.CH.compression_method `Seq.append` (
+       LP.serialize Parsers.ClientHello_compression_methods.clientHello_compression_methods_serializer c2.CH.compression_methods `Seq.append` (
        truncate_clientHelloExtensions c2.CH.extensions
    ))));
   LP.serialize_strong_prefix Parsers.SessionID.sessionID_serializer c1.CH.session_id c2.CH.session_id
      (LP.serialize Parsers.ClientHello_cipher_suites.clientHello_cipher_suites_serializer c1.CH.cipher_suites  `Seq.append` (
-      LP.serialize Parsers.ClientHello_compression_method.clientHello_compression_method_serializer c1.CH.compression_method `Seq.append` (
+      LP.serialize Parsers.ClientHello_compression_methods.clientHello_compression_methods_serializer c1.CH.compression_methods `Seq.append` (
    truncate_clientHelloExtensions c1.CH.extensions
      )))
      (LP.serialize Parsers.ClientHello_cipher_suites.clientHello_cipher_suites_serializer c2.CH.cipher_suites  `Seq.append` (
-       LP.serialize Parsers.ClientHello_compression_method.clientHello_compression_method_serializer c2.CH.compression_method `Seq.append` (
+       LP.serialize Parsers.ClientHello_compression_methods.clientHello_compression_methods_serializer c2.CH.compression_methods `Seq.append` (
        truncate_clientHelloExtensions c2.CH.extensions
    )));
   LP.serialize_strong_prefix CH.clientHello_cipher_suites_serializer c1.CH.cipher_suites c2.CH.cipher_suites
-     (LP.serialize Parsers.ClientHello_compression_method.clientHello_compression_method_serializer c1.CH.compression_method `Seq.append` (
+     (LP.serialize Parsers.ClientHello_compression_methods.clientHello_compression_methods_serializer c1.CH.compression_methods `Seq.append` (
    truncate_clientHelloExtensions c1.CH.extensions
      ))
-     (LP.serialize Parsers.ClientHello_compression_method.clientHello_compression_method_serializer c2.CH.compression_method `Seq.append` (
+     (LP.serialize Parsers.ClientHello_compression_methods.clientHello_compression_methods_serializer c2.CH.compression_methods `Seq.append` (
        truncate_clientHelloExtensions c2.CH.extensions
    ));
-  LP.serialize_strong_prefix CH.clientHello_compression_method_serializer c1.CH.compression_method c2.CH.compression_method
+  LP.serialize_strong_prefix CH.clientHello_compression_methods_serializer c1.CH.compression_methods c2.CH.compression_methods
     (truncate_clientHelloExtensions c1.CH.extensions)
     (truncate_clientHelloExtensions c2.CH.extensions)
   ;
@@ -786,7 +786,7 @@ let handshake_m_client_hello_set_binders
     c'.CH.random == c.CH.random /\
     c'.CH.session_id == c.CH.session_id /\
     c'.CH.cipher_suites == c.CH.cipher_suites /\
-    c'.CH.compression_method == c.CH.compression_method /\
+    c'.CH.compression_methods == c.CH.compression_methods /\
     Cons? l' /\ (
     let l = c.CH.extensions in
     let e = L.last l in

--- a/src/tls/ParsersAux.Binders.fsti
+++ b/src/tls/ParsersAux.Binders.fsti
@@ -33,7 +33,7 @@ val set_binders (m: H.handshake {has_binders m}) (b' : Psks.offeredPsks_binders 
     c'.CH.random == c.CH.random /\
     c'.CH.session_id == c.CH.session_id /\
     c'.CH.cipher_suites == c.CH.cipher_suites /\
-    c'.CH.compression_method == c.CH.compression_method /\
+    c'.CH.compression_methods == c.CH.compression_methods /\
     Cons? c'.CH.extensions /\
     L.init c'.CH.extensions == L.init c.CH.extensions /\
     CHE.CHE_pre_shared_key? (L.last c'.CH.extensions) /\

--- a/src/tls/Pkg.Tree.fst
+++ b/src/tls/Pkg.Tree.fst
@@ -14,6 +14,19 @@ module DT = DefineTable
 /// package. The TLS-specific details are filled-in in KeySchedule.
 
 type t = pkg ii
+let regid : eqtype = Pkg.regid ii
+
+let rec does_not_contain_label (l:list (label * 'a)) (lbl:label) =
+  match l with
+  | [] -> True
+  | (lbl', _) :: t -> lbl <> lbl' /\ does_not_contain_label t lbl
+
+let rec disjoint_labels (l:list (label * 'a)) : Type0 =
+  match l with
+  | [] -> True
+  | (lbl,_)::t -> does_not_contain_label t lbl /\ disjoint_labels t
+
+// FIXME(adl): need to refine children' with disjoint_labels
 
 noeq noextract
 type tree' (par_ideal:Type0) =
@@ -82,13 +95,19 @@ let down (#p:Type0) (u:children p) (l:label{u `has_lbl` l}) : tree p =
   Some?.v (find_lbl u l)
 
 noextract
-let child (#p:Type0) (u:children' p) (l:label{u `has_lbl'` l})
-  : pkg:t{Pkg?.ideal pkg ==> p}
+let child' (#p:Type0) (u:children' p) (l:label{u `has_lbl'` l})
+  : Pure t (requires True) (ensures fun pkg -> Pkg?.ideal pkg ==> p)
   =
   let x : tree' p = down' u l in
   match x with
   | Leaf p -> p
   | Node p c -> p
+
+noextract
+let child (#p:Type0) (u:children p) (l:label{u `has_lbl` l})
+  : Pure t (requires True) (ensures fun pkg -> Pkg?.ideal pkg ==> p)
+  =
+  child' (u <: children' p) l
 
 type initial_state (#p:Type0) (pkg:t{Pkg?.ideal pkg ==> p}) (h:mem) =
   DT.empty (Pkg?.define_table pkg)
@@ -114,8 +133,6 @@ Furthermore, the invariant of a node pacakge implies the
 invariant of every descendent package.
 *)
 
-let regid : eqtype = i:ii.t{ii.registered i}
-
 val tree_inv': #p:Type0 -> t:tree' p -> mem ->
   Ghost Type0 (requires model) (ensures fun _ -> True) (decreases %[t])
 val children_inv': #vt:(regid->Type) -> DT.dt vt -> #p:Type0 -> u:children' p -> mem ->
@@ -130,6 +147,13 @@ let child_instance_inv (#vt:regid->Type) (parent_dt:DT.dt vt)
   | Derive j lbl' ctx -> lbl == lbl' /\
     registered j /\ DT.defined parent_dt j
 
+let rec pairwise_disjoin_dt (#p:Type0) (u:children' p) (l:M.loc) =
+  match u with
+  | [] -> True
+  | (_,p) :: tl ->
+    let pkg = match p with Node p _ -> p | Leaf p -> p in
+    M.loc_disjoint l (DT.loc pkg.define_table) /\ pairwise_disjoin_dt tl l
+
 let rec tree_inv' #p t h =
   match t with
   | Leaf p -> Pkg?.package_invariant p h
@@ -142,6 +166,7 @@ and children_inv' #vt parent_dt #p u h =
   | (lbl,x)::tl ->
     let pkg = match x with Leaf p -> p | Node p _ -> p in
     tree_inv' x h /\ children_inv' parent_dt tl h /\
+    pairwise_disjoin_dt tl (DT.loc pkg.define_table) /\
     M.loc_disjoint (DT.loc parent_dt) (DT.loc pkg.define_table) /\
     DT.dt_forall pkg.define_table (child_instance_inv parent_dt lbl) h
 
@@ -150,6 +175,38 @@ let tree_inv (#p:Type0) (t:tree p) (h:mem) =
 
 let children_inv #vt (dt:DT.dt vt) (#p:Type0) (t:children p) (h:mem) =
   (if model then children_inv' dt (t <: children' p) h else True)
+
+val lemma_derive_children:
+  #vt: (regid->Type) ->
+  dt: DT.dt vt ->
+  #p: Type0 ->
+  u: children' p ->
+  i: regid{DT.defined dt i} ->
+  lbl: label{u `has_lbl'` lbl} ->
+  ctx: context{wellformed_derive i lbl ctx /\ registered (derive i lbl ctx)} ->
+  k: Pkg?.key (child' u lbl) (derive i lbl ctx) ->
+  h0:mem -> h1:mem ->
+  Lemma (requires model /\ children_inv' dt u h0 /\
+    DT.extended (child' u lbl).define_table k h0 h1 /\
+    (child' u lbl).package_invariant h1)
+  (ensures children_inv' dt u h1)
+  (decreases %[u])
+
+val lemma_derive_tree:
+  #p: Type0 ->
+  t: tree' p ->
+  h0:mem -> l:M.loc -> h1:mem ->
+  Lemma (requires model /\ tree_inv' t h0 /\ M.modifies l h0 h1 /\
+    M.loc_disjoint l l)
+  (ensures tree_inv' t h1)
+  (decreases %[t])
+
+(*
+let rec lemma_derive_children #vt dt #p u i lbl ctx k h0 h1 =
+and lemma_derive_tree #p t h0 l h1 =
+*)
+
+(**** Relating indexes to tree paths ****)
 
 noextract
 let rec labels_of_id (i:pre_id) (acc:list label) =
@@ -163,6 +220,7 @@ let y : label = assume false; "y"
 let _ = assert_norm (labels_of_id (Derive(Derive (Preshared Hashing.Spec.SHA1 0) x Extract) y Extract) [] == [x; y])
 *)
 
+(*
 let rec subtree (#p:Type0) (t:tree' p)
   (#q:Type0) (c:children' q) (l:list label)
   : Pure Type (requires model) (ensures fun _ -> True) (decreases %[l])
@@ -174,6 +232,7 @@ let rec subtree (#p:Type0) (t:tree' p)
     let c' = Node?.children t in
     c' `has_lbl'` lbl /\
     subtree (down' c' lbl) c tl)
+*)
 
 let rec defined_path (#p:Type0) (t:tree' p) (l:list label)
   : GTot Type (decreases %[l]) =
@@ -210,51 +269,23 @@ let defined' (#p:Type0) (t:tree' p) (i:regid{model}) =
 let defined (#p:Type0) (t:tree p) (i:regid) =
   if model then defined' (t <: tree' p) i else True
 
-val lemma_derive_children:
-  #vt: (regid->Type) ->
-  dt: DT.dt vt ->
-  #p: Type0 ->
-  u: children' p ->
-  i: regid{DT.defined dt i} ->
-  lbl: label{u `has_lbl'` lbl} ->
-  ctx: context{wellformed_derive i lbl ctx /\ registered (derive i lbl ctx)} ->
-  k: Pkg?.key (child u lbl) (derive i lbl ctx) ->
-  h0:mem -> h1:mem ->
-  Lemma (requires model /\ children_inv' dt u h0 /\
-    DT.extended (child u lbl).define_table k h0 h1 /\
-    (child u lbl).package_invariant h1)
-  (ensures children_inv' dt u h1)
-  (decreases %[u])
-
-val lemma_derive_tree:
-  #p: Type0 ->
-  t: tree' p ->
-  h0:mem -> l:M.loc -> h1:mem ->
-  Lemma (requires model /\ tree_inv' t h0 /\ M.modifies l h0 h1 /\
-    M.loc_disjoint l l)
-  (ensures tree_inv' t h1)
-  (decreases %[t])
-
-(*
-// Local subtree invariant restoration
-let rec lemma_derive 
+let lemma_tree_inv_frame_local_instance
+  (#p:Type) (t:tree' p)
+  (pkg:local_pkg ii)
+  (i: regid)
+  (k: LocalPkg?.key pkg i)
+  (h0 h1:mem)
+  : Lemma
+    (requires model /\ tree_inv' t h0 /\ defined' t i /\
+      locally_packaged (get_package t (labels_of_id i [])) pkg /\
+      M.modifies (pkg.local_footprint k) h0 h1 /\
+      LocalPkg?.inv pkg k h1)
+    (ensures tree_inv' t h1)
   =
-  match u with
-  | [] -> ()
-  | (lbl', t) :: tl ->
-    if lbl = lbl' then
-     begin
-      lemma_
-     end
-    else lemma_derive dt tl i lbl ctx k h0 h1
-  
-  let rec aux
-    : Lemma ()
-    =
-    admit()
-    in
+  let p = get_package t (labels_of_id i []) in
+  DT.lemma_forall_frame p.define_table pkg.inv pkg.local_footprint pkg.inv_framing h0 M.loc_none h1;
   admit()
-*)
+
 
 (*
 Building the tree is quite technical because the tree

--- a/src/tls/Pkg.Tree.fst
+++ b/src/tls/Pkg.Tree.fst
@@ -4,6 +4,7 @@ open Mem
 open Pkg
 open Idx
 
+module M = LowStar.Modifies
 module DT = DefineTable
 
 /// We use subtrees to specify KDF usages. We hope we can erase
@@ -22,7 +23,7 @@ and children' (par_ideal:Type0) = list (label * tree' par_ideal)
 
 // would prefer to use Map.t, but positivity check fails
 
-inline_for_extraction
+inline_for_extraction noextract
 let max x y = if x <= y then y else x
 
 // induction on n-ary trees requires explicit termination
@@ -47,43 +48,220 @@ type tree (p:Type0) =
 type children (p:Type0) =
   (if model then children' p else no_tree)
 
+// Used to start building children
+inline_for_extraction noextract
+let no_children (p:Type0) : children p =
+  (if model then [] <: children' p else erased_tree)
+
 inline_for_extraction
-let rec find_lbl (#p:Type0) (u:children p) (l: label) : option (tree p) =
-  if model then
-    let u' : children' p = u in
-    match u' with
-    | [] -> None
-    | (lbl, t) :: tl ->
-      if lbl = l then Some t
-      else
-	let tl : children p = tl in
-	find_lbl tl l
-  else None
+let rec find_lbl' (#p:Type0) (u:children' p) (l: label) : option (tree' p) =
+  match u with
+  | [] -> None
+  | (lbl, t) :: tl ->
+    if lbl = l then Some t
+    else find_lbl' tl l
+
+noextract
+let rec find_lbl (#p:Type0) (u:children p) (l:label) : option (tree p) =
+  if model then find_lbl' (u <: children' p) l else None
+
+inline_for_extraction
+let has_lbl' (#p:Type0) (u:children' p) (l: label) =
+  Some? (find_lbl' u l)
 
 inline_for_extraction
 let has_lbl (#p:Type0) (u:children p) (l: label) =
-  if model then Some? (find_lbl u l) else false
+  if model then (u <: children' p) `has_lbl'` l else false
+
+noextract
+let down' (#p:Type0) (u:children' p) (l:label{u `has_lbl'` l}) : tree' p =
+  Some?.v (find_lbl' u l)
 
 noextract
 let down (#p:Type0) (u:children p) (l:label{u `has_lbl` l}) : tree p =
   Some?.v (find_lbl u l)
 
 noextract
-let child (#p:Type0) (u:children p) (l:label{model /\ u `has_lbl` l})
+let child (#p:Type0) (u:children' p) (l:label{u `has_lbl'` l})
   : pkg:t{Pkg?.ideal pkg ==> p}
   =
-  let x : tree' p = down u l in
+  let x : tree' p = down' u l in
   match x with
   | Leaf p -> p
   | Node p c -> p
 
+type initial_state (#p:Type0) (pkg:t{Pkg?.ideal pkg ==> p}) (h:mem) =
+  DT.empty (Pkg?.define_table pkg)
+
+(**** Tree invariant ****)
+
 (*
-let rec index_consistent (#p:Type0) (u:children p)
-  (#it:eqtype) (#vt:it->Type) (t:DT.dt vt) (h:mem) =
-  if model then
-    let u' : children' p = u in
-    match u with
-    | [] -> True
-    | (lbl,t) :: tl -> True
-  else True
+
+The structure of indexes defined in each package of the tree
+follows the structure of the tree itself:
+
+      KDF   package invariant = children invariant of usage
+     / | \
+    a  b  c   derivation labels
+   /   |   \
+[ X    Y    Z ] children (KDF usage)
+           / \
+
+if (x i) is an instance of package X, then i must be of the
+form Derive j a ctx where j is defined in KDF.
+
+Furthermore, the invariant of a node pacakge implies the
+invariant of every descendent package.
 *)
+
+let regid : eqtype = i:ii.t{ii.registered i}
+
+val tree_inv': #p:Type0 -> t:tree' p -> mem ->
+  Ghost Type0 (requires model) (ensures fun _ -> True) (decreases %[t])
+val children_inv': #vt:(regid->Type) -> DT.dt vt -> #p:Type0 -> u:children' p -> mem ->
+  Ghost Type0 (requires model) (ensures fun _ -> True) (decreases %[u])
+
+let child_instance_inv (#vt:regid->Type) (parent_dt:DT.dt vt)
+  (lbl:label) (#kt:regid->Type) (#i:regid) (k:kt i) (h:mem)
+  : Ghost Type0 (requires model) (ensures fun _ -> True) =
+  let i : pre_id = i in
+  match i  with
+  | Preshared _ _ -> False
+  | Derive j lbl' ctx -> lbl == lbl' /\
+    registered j /\ DT.defined parent_dt j
+
+let rec tree_inv' #p t h =
+  match t with
+  | Leaf p -> Pkg?.package_invariant p h
+  | Node p u -> Pkg?.package_invariant p h /\
+    children_inv' p.define_table u h
+
+and children_inv' #vt parent_dt #p u h =
+  match u with
+  | [] -> True
+  | (lbl,x)::tl ->
+    let pkg = match x with Leaf p -> p | Node p _ -> p in
+    tree_inv' x h /\ children_inv' parent_dt tl h /\
+    M.loc_disjoint (DT.loc parent_dt) (DT.loc pkg.define_table) /\
+    DT.dt_forall pkg.define_table (child_instance_inv parent_dt lbl) h
+
+let tree_inv (#p:Type0) (t:tree p) (h:mem) =
+  (if model then tree_inv' (t <: tree' p) h else True)
+
+let children_inv #vt (dt:DT.dt vt) (#p:Type0) (t:children p) (h:mem) =
+  (if model then children_inv' dt (t <: children' p) h else True)
+
+noextract
+let rec labels_of_id (i:pre_id) (acc:list label) =
+  match i with
+  | Preshared a pski -> acc
+  | Derive i l ctx -> labels_of_id i (l::acc)
+
+(*
+let x : label = assume false; "x"
+let y : label = assume false; "y"
+let _ = assert_norm (labels_of_id (Derive(Derive (Preshared Hashing.Spec.SHA1 0) x Extract) y Extract) [] == [x; y])
+*)
+
+let rec subtree (#p:Type0) (t:tree' p)
+  (#q:Type0) (c:children' q) (l:list label)
+  : Pure Type (requires model) (ensures fun _ -> True) (decreases %[l])
+  =
+  Node? t /\
+  (match l with
+  | [] -> q == Pkg?.ideal (Node?.node t) /\ Node?.children t == c
+  | lbl::tl ->
+    let c' = Node?.children t in
+    c' `has_lbl'` lbl /\
+    subtree (down' c' lbl) c tl)
+
+let rec defined_path (#p:Type0) (t:tree' p) (l:list label)
+  : GTot Type (decreases %[l]) =
+  match t with
+  | Leaf _ -> l == []
+  | Node p c ->
+    match l with
+    | [] -> False
+    | lbl::tl -> c `has_lbl'` lbl /\ defined_path (down' c lbl) tl
+
+let rec get_package (#p:Type0) (t:tree' p) (l:list label{defined_path t l})
+  : GTot (pkg ii) (decreases %[l]) =
+  match t with
+  | Leaf p -> p
+  | Node p c ->
+    match l with
+    | lbl :: tl -> get_package (down' c lbl) tl
+
+let rec get_usage (#p:Type0) (t:tree' p) (l:list label{defined_path t l})
+  : GTot (p:Type0 & children' p) (decreases %[l]) =
+  match t with
+  | Leaf p -> (| Pkg?.ideal p, ([] <: children' (Pkg?.ideal p)) |)
+  | Node pkg c ->
+    match l with
+    | [] -> (| p, c |)
+    | lbl :: tl -> get_usage (down' c lbl) tl
+
+let defined' (#p:Type0) (t:tree' p) (i:regid{model}) =
+  let path = labels_of_id i [] in
+  defined_path t path /\
+  (let pkg = get_package t path in
+  DT.defined pkg.define_table i)
+
+let defined (#p:Type0) (t:tree p) (i:regid) =
+  if model then defined' (t <: tree' p) i else True
+
+val lemma_derive_children:
+  #vt: (regid->Type) ->
+  dt: DT.dt vt ->
+  #p: Type0 ->
+  u: children' p ->
+  i: regid{DT.defined dt i} ->
+  lbl: label{u `has_lbl'` lbl} ->
+  ctx: context{wellformed_derive i lbl ctx /\ registered (derive i lbl ctx)} ->
+  k: Pkg?.key (child u lbl) (derive i lbl ctx) ->
+  h0:mem -> h1:mem ->
+  Lemma (requires model /\ children_inv' dt u h0 /\
+    DT.extended (child u lbl).define_table k h0 h1 /\
+    (child u lbl).package_invariant h1)
+  (ensures children_inv' dt u h1)
+  (decreases %[u])
+
+val lemma_derive_tree:
+  #p: Type0 ->
+  t: tree' p ->
+  h0:mem -> l:M.loc -> h1:mem ->
+  Lemma (requires model /\ tree_inv' t h0 /\ M.modifies l h0 h1 /\
+    M.loc_disjoint l l)
+  (ensures tree_inv' t h1)
+  (decreases %[t])
+
+(*
+// Local subtree invariant restoration
+let rec lemma_derive 
+  =
+  match u with
+  | [] -> ()
+  | (lbl', t) :: tl ->
+    if lbl = lbl' then
+     begin
+      lemma_
+     end
+    else lemma_derive dt tl i lbl ctx k h0 h1
+  
+  let rec aux
+    : Lemma ()
+    =
+    admit()
+    in
+  admit()
+*)
+
+(*
+Building the tree is quite technical because the tree
+invariant must be initialized (which requires the define
+table of the parent to be allocated before children can be
+defined.
+
+We provide stateful helper functions to help construct trees
+*)
+

--- a/src/tls/Pkg.Tree.fst
+++ b/src/tls/Pkg.Tree.fst
@@ -4,6 +4,8 @@ open Mem
 open Pkg
 open Idx
 
+module DT = DefineTable
+
 /// We use subtrees to specify KDF usages. We hope we can erase
 /// them when modelling is off!
 ///
@@ -47,15 +49,16 @@ type children (p:Type0) =
 
 inline_for_extraction
 let rec find_lbl (#p:Type0) (u:children p) (l: label) : option (tree p) =
-  if not model then None else
-  let u' : children' p = u in
-  match u' with
-  | [] -> None
-  | (lbl, t) :: tl ->
-    if lbl = l then Some t
-    else
-      let tl : children p = tl in
-      find_lbl tl l
+  if model then
+    let u' : children' p = u in
+    match u' with
+    | [] -> None
+    | (lbl, t) :: tl ->
+      if lbl = l then Some t
+      else
+	let tl : children p = tl in
+	find_lbl tl l
+  else None
 
 inline_for_extraction
 let has_lbl (#p:Type0) (u:children p) (l: label) =
@@ -73,3 +76,14 @@ let child (#p:Type0) (u:children p) (l:label{model /\ u `has_lbl` l})
   match x with
   | Leaf p -> p
   | Node p c -> p
+
+(*
+let rec index_consistent (#p:Type0) (u:children p)
+  (#it:eqtype) (#vt:it->Type) (t:DT.dt vt) (h:mem) =
+  if model then
+    let u' : children' p = u in
+    match u with
+    | [] -> True
+    | (lbl,t) :: tl -> True
+  else True
+*)

--- a/src/tls/Pkg.fst
+++ b/src/tls/Pkg.fst
@@ -18,6 +18,7 @@ module Pkg
 
 open Mem
 
+module M = LowStar.Modifies
 module MDM = FStar.Monotonic.DependentMap
 module MH = FStar.Monotonic.Heap
 module HS = FStar.HyperStack
@@ -87,9 +88,14 @@ noeq type pkg_inv_r =
   | Pinv_region: r:rid{r `disjoint` tls_define_region} -> pkg_inv_r
   | Pinv_define: #it:eqtype -> #vt:(it -> Type) -> t:mem_table vt -> pkg_inv_r
 
+
+
 // When calling create or coerce, the footprint of a package grows only with
 // fresh subregions
-type modifies_footprint (fp:mem->GTot rset) h0 h1 =
+type modifies_footprint (fp: mem -> GTot M.loc) h0 h1 =
+  M.loc_includes (fp h0) (fp h1) /\
+  forall (l:M.loc).{:pattern }
+    l `M.loc_includes` (fp h0) /\ loc
   forall (r:rid). (Set.mem r (fp h0) /\ ~(Set.mem r (fp h1))) ==> fresh_region r h0 h1  
   //AR: 12/05: Could use the pattern {:pattern (Set.mem r (fp h0)); (Set.mem r (fp h1))}
 

--- a/src/tls/Pkg.fst
+++ b/src/tls/Pkg.fst
@@ -92,7 +92,7 @@ type modifies_footprint (fp: mem -> GTot M.loc) h0 h1 =
 //AR: 12/05: Could use the pattern {:pattern (Set.mem r (fp h0)); (Set.mem r (fp h1))}
 *)
 
-inline_for_extraction
+inline_for_extraction noextract
 noeq type pkg (ip: ipkg) = | Pkg:
   key: (regid ip -> Type0)  (* indexed state of the functionality *) ->
   info: (ip.t -> Type0)                     (* creation-time arguments, typically refined using i:ip.t *) ->
@@ -155,7 +155,7 @@ noeq type pkg (ip: ipkg) = | Pkg:
 /// packages of instances with local private state, before ensuring
 /// their unique definition at every index and the disjointness of
 /// their footprints.
-inline_for_extraction
+inline_for_extraction noextract
 noeq type local_pkg (ip: ipkg) =
 | LocalPkg:
   key: (regid ip -> Type0) ->
@@ -281,6 +281,7 @@ let memoization (#ip:ipkg) (p:local_pkg ip) ($dt:DT.dt p.key) : pkg ip
     (fun #_ _ _ h -> True) (fun #_ _ _ _ _ _ -> ())
     create p.coerceT coerce)
 
+noextract
 let locally_packaged (#ip:ipkg) (p:pkg ip) (p':local_pkg ip) =
   LocalPkg?.key p' == Pkg?.key p /\
   p == memoization p' p.define_table

--- a/src/tls/Pkg.fst
+++ b/src/tls/Pkg.fst
@@ -18,6 +18,7 @@ module Pkg
 
 open Mem
 
+module DT = DefineTable
 module M = LowStar.Modifies
 module MDM = FStar.Monotonic.DependentMap
 module MH = FStar.Monotonic.Heap
@@ -78,26 +79,17 @@ noeq type ipkg = | Idx:
 /// Derived key length restriction when using HKDF
 type keylen = l:UInt32.t {0 < UInt32.v l /\ UInt32.v l <= 255}
 
-
-(* Definedness *)
-
-// Framing of package invariants can be done w.r.t either a region that is
-// disjoint from tls_define_region, or a define table that must be at a
-// different address than the package's define_table
-noeq type pkg_inv_r =
-  | Pinv_region: r:rid{r `disjoint` tls_define_region} -> pkg_inv_r
-  | Pinv_define: #it:eqtype -> #vt:(it -> Type) -> t:mem_table vt -> pkg_inv_r
-
+(*
 // When calling create or coerce, the footprint of a package grows only with
 // fresh subregions
 type modifies_footprint (fp: mem -> GTot M.loc) h0 h1 =
   M.loc_includes (fp h0) (fp h1) /\
   (forall (l:M.loc).{:pattern (M.loc_includes l (fp h1)); (M.loc_disjoint l (fp h1))}
     l `M.loc_includes` (fp h1) /\ l `M.loc_disjoint` (fp h0) ==> fresh_loc l h0 h1)
-
 // Old region-based definition:
 //  forall (r:rid). (Set.mem r (fp h0) /\ ~(Set.mem r (fp h1))) ==> fresh_region r h0 h1  
-  //AR: 12/05: Could use the pattern {:pattern (Set.mem r (fp h0)); (Set.mem r (fp h1))}
+//AR: 12/05: Could use the pattern {:pattern (Set.mem r (fp h0)); (Set.mem r (fp h1))}
+*)
 
 inline_for_extraction
 noeq type pkg (ip: ipkg) = | Pkg:
@@ -111,24 +103,19 @@ noeq type pkg (ip: ipkg) = | Pkg:
   //
   // The package footprint is a function of the table contents;
   // that collects all global and instance-local regions, but not [define_table]
-  define_table: mem_table #(i:ip.t {ip.registered i}) key ->
+  define_table: DT.dt key ->
   footprint: (mem -> GTot M.loc) ->
   footprint_framing: (h0:mem -> h1:mem -> Lemma
-    (requires mem_stable define_table h0 h1)
+    (requires DT.unchanged define_table h0 h1)
     (ensures footprint h0 == footprint h1)) ->
 
   // we maintain a package invariant,
   // which only depends on the table and footpring.
   package_invariant: (mem -> Type0) ->
   package_invariant_framing: (h0:mem -> l:M.loc -> h1:mem -> Lemma
-    (requires M.modifies l h0 h1 /\
-      package_invariant h0 /\
-      mem_contains define_table h0 /\
-      M.loc_disjoint l (footprint h0))
-//      (match r with
-//      | Pinv_region r -> modifies_one r h0 h1 /\ ~(Set.mem r (footprint h0))
-//      | Pinv_define #it #vt t ->
-//        mem_contains t h0 /\ modifies_mem_table t h0 h1 /\ mem_disjoint t define_table))
+    (requires package_invariant h0 /\
+      M.modifies l h0 h1 /\ define_table `DT.live` h0 /\
+      M.loc_disjoint l (DT.loc define_table) /\ M.loc_disjoint l (footprint h0))
     (ensures package_invariant h1)) ->
 
   // create and coerce, with a shared post-condition and framing lemma
@@ -137,31 +124,30 @@ noeq type pkg (ip: ipkg) = | Pkg:
   post: (#i:ip.t{ip.registered i} -> info i -> key i -> mem -> GTot Type0) ->
   post_framing: (#i:ip.t{ip.registered i} -> a:info i -> k:key i ->
     h0:mem -> l:M.loc -> h1:mem -> Lemma
-     (requires post a k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l (footprint h0))
+     (requires post a k h0 /\
+       M.modifies l h0 h1 /\ define_table `DT.live` h0 /\
+       M.loc_disjoint l (DT.loc define_table) /\ M.loc_disjoint l (footprint h0))
      (ensures post a k h1)) ->
 
   create: (i:ip.t{ip.registered i} -> a:info i -> ST (key i)
-    (requires fun h0 ->
-      model /\
+    (requires fun h0 -> model /\
       package_invariant h0 /\
-      mem_fresh define_table i h0)
+      DT.fresh define_table i h0)
     (ensures fun h0 k h1 ->
       post a k h1 /\ package_invariant h1 /\
-      modifies_mem_table define_table h0 h1 /\
-      modifies_footprint footprint h0 h1 /\
-      mem_update define_table i k h0 h1)) ->
+      (footprint h1) `M.loc_includes` (footprint h0) /\
+      DT.extended define_table i k h0 h1)) ->
 
   coerceT: (i:ip.t{ip.registered i /\ (ideal ==> ~(ip.honest i))} -> a:info i -> lbytes32 (len a) -> GTot (key i)) ->
   coerce: (i:ip.t{ip.registered i /\ (ideal ==> ~(ip.honest i))} -> a:info i -> rk: lbytes32 (len a) -> ST (key i)
     (requires fun h0 ->
       package_invariant h0 /\
-      mem_fresh define_table i h0)
+      DT.fresh define_table i h0)
     (ensures fun h0 k h1 ->
       k == coerceT i a rk /\
       post a k h1 /\ package_invariant h1 /\
-      modifies_mem_table define_table h0 h1 /\
-      modifies_footprint footprint h0 h1 /\
-      mem_update define_table i k h0 h1)) ->
+      (footprint h1) `M.loc_includes` (footprint h0) /\
+      DT.extended define_table i k h0 h1)) ->
   pkg ip
 
 /// packages of instances with local private state, before ensuring
@@ -173,98 +159,26 @@ noeq type local_pkg (ip: ipkg) =
   key: (i:ip.t{ip.registered i} -> Type0) ->
   info: (ip.t -> Type0) ->
   len: (#i:ip.t -> info i -> keylen) ->
-  ideal: Type0 ->
-  shared_footprint: M.loc ->
-  local_footprint: (#i:ip.t{ip.registered i} -> key i -> GTot (l:M.loc{M.loc_disjoint l shared_footprint})) ->
-  local_invariant: (#i:ip.t{ip.registered i} -> key i -> mem -> GTot Type0) ->
-  local_invariant_framing: (i:ip.t{ip.registered i} -> k:key i ->
+  ideal: Type0{ideal ==> model} ->
+  parent: M.loc ->
+  local_footprint: DT.local_fp key parent ->
+  inv: (#i:ip.t{ip.registered i} -> key i -> mem -> GTot Type0) ->
+  inv_framing: (#i:ip.t{ip.registered i} -> k:key i ->
     h0:mem -> l:M.loc -> h1:mem -> Lemma
-    (requires local_invariant k h0 /\ M.modifies l h0 h1
-      /\ M.loc_disjoint l shared_footprint /\ M.loc_disjoint l (local_footprint k))
-    (ensures local_invariant k h1)) ->
-  post: (#i:ip.t{ip.registered i} -> info i -> key i -> mem -> GTot Type0) ->
-  post_framing: (#i:ip.t{ip.registered i} -> a:info i -> k:key i ->
-    h0:mem -> l:M.loc -> h1:mem -> Lemma
-    (requires post a k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l (local_footprint k))
-    (ensures post a k h1)) ->
+    (requires inv k h0 /\ M.modifies l h0 h1 /\ M.loc_disjoint l (local_footprint k))
+    (ensures inv k h1)) ->
   create: (i:ip.t{ip.registered i} -> a:info i -> ST (key i)
     (requires fun h0 -> model)
-    (ensures fun h0 k h1 ->
-       M.modifies (local_footprint k) h0 h1 /\ local_invariant k h1 /\
-       post a k h1 /\ fresh_loc (local_footprint k) h0 h1)) ->
+    (ensures fun h0 k h1 -> M.modifies M.loc_none h0 h1 /\
+       inv k h1 /\ fresh_loc (local_footprint k) h0 h1)) ->
   coerceT: (i:ip.t{ip.registered i /\ (ideal ==> ~(ip.honest i))} ->
     a:info i -> lbytes32 (len a) -> GTot (key i)) ->
   coerce: (i:ip.t{ip.registered i /\ (ideal ==> ~(ip.honest i))} ->
     a:info i -> rk:lbytes32 (len a) -> ST (key i)
     (requires fun h0 -> True)
-    (ensures fun h0 k h1 -> k == coerceT i a rk /\
-      M.modifies (local_footprint k) h0 h1 /\ local_invariant k h1 /\
-      post a k h1 /\ fresh_loc (local_footprint k) h0 h1)) ->
+    (ensures fun h0 k h1 -> k == coerceT i a rk /\ M.modifies M.loc_none h0 h1 /\
+      inv k h1 /\ fresh_loc (local_footprint k) h0 h1)) ->
   local_pkg ip
-
-(* Iterators over Monotonic.Map, require a change of implementation *)
-(* cwinter: this is now a Monotonic.DependentMap *)
-(* 2018.05.26 SZ: I can't find anything like these in Monotonic.DependentMap; cwinter? *)
-let mm_fold (#a:eqtype) (#b:a -> Type) (t:MDM.map a b)
-  (#rt:Type) (init:rt) (folder:(rt -> i:a -> b i -> GTot rt)) : GTot rt
-  = admit()
-
-let mm_fold_grow (#a:eqtype) (#b:a -> Type) (t:MDM.map a b) (t':MDM.map a b) (i:a) (v:b i)
-  (#rt:Type) (init:rt) (folder:(rt -> i:a -> b i -> GTot rt)) : Lemma
-  (requires t' == MDM.upd t i v)
-  (ensures mm_fold t' init folder == folder (mm_fold t init folder) i v)
-  = admit()
-
-assume type mm_forall (#a:eqtype) (#b:a -> Type) (t:MDM.map a b)
-  (p: (#i:a -> b i -> mem -> GTot Type0)) (h:mem)
-
-let lemma_mm_forall_frame (#a:eqtype) (#b:a -> Type) (t:MDM.map a b)
-  (p: (#i:a -> b i -> mem -> GTot Type0))
-  (footprint: (#i:a -> v:b i -> GTot M.loc))
-  (p_frame: (i:a -> v:b i -> h0:mem -> r:rid -> h1:mem ->
-    Lemma (requires p v h0 /\ modifies_one r h0 h1 /\ ~(Set.mem r (footprint v)))
-          (ensures p v h1)))
-  (r:rid) (h0 h1:mem)
-  : Lemma (requires mm_forall t p h0 /\ modifies_one r h0 h1 /\
-            ~(Set.mem r (mm_fold t #rset Set.empty (fun s i k -> rset_union s (footprint k)))))
-          (ensures mm_forall t p h1)
-  = admit()
-
-let lemma_mm_forall_extend (#a:eqtype) (#b:a -> Type) (t:MDM.map a b) (t':MDM.map a b)
-  (p: (#i:a -> b i -> mem -> GTot Type0)) (i:a) (v:b i) (h0 h1:mem)
-  : Lemma (requires mm_forall t p h1 /\ t' == MDM.upd t i v /\ p v h1)
-          (ensures mm_forall t' p h1)
-  = admit()
-
-let lemma_mm_forall_init (#a:eqtype) (#b:a -> Type) (t:MDM.map a b)
-  (p: (#i:a -> b i -> mem -> GTot Type0)) (h:mem)
-  : Lemma (requires t == MDM.empty)
-          (ensures mm_forall t p h)
-  = admit()
-
-let lemma_mm_forall_elim (#a:eqtype) (#b:a -> Type) (t:MDM.map a b)
-  (p: (#i:a -> b i -> mem -> GTot Type0)) (i:a) (v:b i) (h:mem)
-  : Lemma (requires mm_forall t p h /\ MDM.sel t i == Some v)
-          (ensures p v h)
-  = admit()
-
-let lemma_union_com (s1:rset) (s2:rset) (s3:rset)
-  : Lemma (rset_union s1 (rset_union s2 s3) == rset_union (rset_union s1 s2) s3)
-  = admit()
-
-(* obsolete, replaced by refinement of memoize_ST
-unfold type mem_package (#ip:ipkg) (p:local_pkg ip) =
-  p':pkg ip{
-    Pkg?.key p' == LocalPkg?.key p /\
-    Pkg?.info p' == LocalPkg?.info p /\
-    Pkg?.len p' == LocalPkg?.len p /\
-    Pkg?.ideal p' == LocalPkg?.ideal p /\
-    (forall (#i:ip.t{ip.registered i}) (k:p.key i) (h:mem).
-      (mem_defined p'.define_table i /\ p'.package_invariant h) ==> p.local_invariant k h) /\
-    (forall (#i:ip.t{ip.registered i}) (a:p.info i) (k:p.key i) (h:mem).
-      (Pkg?.post p') #i (a <: Pkg?.info p' i) (k <: Pkg?.key p' i) h ==> (LocalPkg?.post p) #i a k h)
-  }
-*)
 
 // Memoization functor from local to global packages that memoize
 // instances produced by create/coerce and maintain their joint
@@ -274,187 +188,115 @@ unfold type mem_package (#ip:ipkg) (p:local_pkg ip) =
 // table-allocating functor; the latter is probably too opaque for
 // correlating its result with the source definitions.
 
-#set-options "--z3rlimit 100 --admit_smt_queries true"
-//unfold
-inline_for_extraction
-noextract
-let memoization (#ip:ipkg) (p:local_pkg ip) ($mtable: mem_table p.key): pkg ip =
+//#set-options "--z3rlimit 100"
+inline_for_extraction noextract
+let memoization (#ip:ipkg) (p:local_pkg ip) ($dt:DT.dt p.key)
+  : Pure (pkg ip)
+  (requires M.loc_disjoint (DT.loc dt) p.parent)
+  (ensures fun _ -> True)
+  =  
   [@inline_let]
-  let footprint_extend (s:rset) (i:ip.t{ip.registered i}) (k:p.key i) =
-    rset_union s (p.local_footprint k)
-    in
+  let footprint h = DT.footprint dt p.local_footprint h in    
   [@inline_let]
-  let footprint (h:mem): GTot rset =
-    let instances_footprint =
-      if model then
-        let map = HS.sel h (itable mtable) in
-        mm_fold map #rset Set.empty footprint_extend
-      else Set.empty in
-    rset_union p.shared_footprint instances_footprint
-    in
+  let package_invariant h = DT.dt_forall dt p.inv h in    
   [@inline_let]
-  let footprint_grow (h0:mem) (i:ip.t{ip.registered i}) (k:p.key i) (h1:mem) : Lemma
-    (requires (mem_update mtable i k h0 h1 /\ fresh_regions (p.local_footprint k) h0 h1))
-    (ensures (modifies_footprint footprint h0 h1))
+  let package_invariant_framing (h0:mem) (l:M.loc) (h1:mem)
+    : Lemma
+      (requires package_invariant h0 /\
+        M.modifies l h0 h1 /\ dt `DT.live` h0 /\
+        M.loc_disjoint l (DT.loc dt) /\ M.loc_disjoint l (footprint h0))
+      (ensures package_invariant h1)
     =
-    if model then
-     begin
-      let map = HS.sel h0 (itable mtable) in
-      let map = HS.sel h1 (itable mtable) in
-      let fp0 = footprint h0 in
-      let fp1 = footprint h1 in
-      mm_fold_grow map map i k #rset Set.empty footprint_extend;
-      assert(fp1 == rset_union p.shared_footprint (rset_union (mm_fold map #rset Set.empty footprint_extend) (p.local_footprint k)));
-      lemma_union_com p.shared_footprint (mm_fold map #rset Set.empty footprint_extend) (p.local_footprint k);
-      assert(fp1 == rset_union fp0 (p.local_footprint k));
-      assert(forall (r:rid). (Set.mem r fp1 /\ ~(Set.mem r fp0)) ==> Set.mem r (p.local_footprint k));
-      assert(modifies_footprint footprint h0 h1)
-     end
-    else ()
+    DT.lemma_forall_frame dt p.inv p.local_footprint p.inv_framing h0 l h1
     in
-  [@inline_let]
-  let footprint_framing (h0:mem) (h1:mem) : Lemma
-    (requires mem_stable mtable h0 h1)
-    (ensures footprint h0 == footprint h1)
-    = ()
-  in
-  [@inline_let]
-  let package_invariant h =
-    (model ==>
-      (let log : i_mem_table p.key = itable mtable in
-      mm_forall (HS.sel h log) p.local_invariant h))
-    in
-  [@inline_let]
-  let ls_footprint (#i:ip.t{ip.registered i}) (k:p.key i) =
-    rset_union (p.local_footprint k) p.shared_footprint
-    in
-  [@inline_let]
-  let ls_footprint_frame (i:ip.t{ip.registered i}) (k:p.key i) (h0:mem) (r:rid) (h1:mem)
-    : Lemma (requires p.local_invariant k h0 /\ modifies_one r h0 h1
-                      /\ ~(r `Set.mem` ls_footprint k))
-            (ensures p.local_invariant k h1)
-    =
-    assert(~(r `Set.mem` ls_footprint k) <==> ~(r `Set.mem` p.local_footprint k) /\ ~(r `Set.mem` p.shared_footprint));
-    p.local_invariant_framing i k h0 r h1
-    in
-  [@inline_let]
-  let package_invariant_framing (h0:mem) (r:pkg_inv_r) (h1:mem) : Lemma
-    (requires package_invariant h0 /\ mem_contains mtable h0 /\
-      (match r with
-      | Pinv_region r -> modifies_one r h0 h1 /\ ~(Set.mem r (footprint h0))
-      | Pinv_define #it #vt t -> mem_contains t h0 /\ modifies_mem_table t h0 h1 /\ mem_disjoint t mtable))
-    (ensures package_invariant h1)
-  =
-    if model then
-      let map = HS.sel h0 (itable mtable) in
-      assert(mm_forall map p.local_invariant h0);
-      (match r with
-      | Pinv_region r ->
-        assert(modifies_one r h0 h1 /\ r `disjoint` tls_define_region);
-        lemma_mm_forall_frame map p.local_invariant ls_footprint ls_footprint_frame r h0 h1;
-        lemma_mem_frame mtable h0 r h1
-      | Pinv_define t ->
-        assert(modifies_mem_table t h0 h1 /\ mem_disjoint t mtable);
-        lemma_mm_forall_frame map p.local_invariant ls_footprint ls_footprint_frame tls_define_region h0 h1;
-        lemma_mem_disjoint_stable t mtable h0 h1)
-    else () in
   [@inline_let]
   let create (i:ip.t{ip.registered i}) (a:p.info i) : ST (p.key i)
-    (requires fun h0 -> model /\ package_invariant h0 /\ mem_fresh mtable i h0)
-    (ensures fun h0 k h1 -> modifies_mem_table mtable h0 h1
-      /\ modifies_footprint footprint h0 h1 /\ p.post a k h1
-      /\ package_invariant h1 /\ mem_update mtable i k h0 h1)
+    (requires fun h0 -> model /\ package_invariant h0 /\ DT.fresh dt i h0)
+    (ensures fun h0 k h1 -> package_invariant h1 /\
+      (footprint h1) `M.loc_includes` (footprint h0) /\
+      DT.extended dt i k h0 h1)
     =
     let h0 = get () in
-    let tbl : i_mem_table p.key = itable mtable in
-    recall tbl;
+    let t0 = DT.ideal dt in
+    assert_norm(DT.loc dt == (if model then M.loc_mreference t0 else M.loc_none));
+    assert(DT.loc dt == M.loc_mreference t0);
+    recall t0;
+    assert_norm(DT.live dt h0 == (model ==> h0 `HS.contains` (DT.ideal dt)));
     let k : p.key i = p.create i a in
     let h1 = get() in
-    assert(HS.sel h0 tbl == HS.sel h1 tbl);
-    package_invariant_framing h0 (Pinv_region tls_tables_region) h1;
-    MDM.extend tbl i k;
+    DT.lemma_footprint_frame dt p.local_footprint h0 h1;
+    DT.lemma_forall_frame dt p.inv p.local_footprint p.inv_framing h0 M.loc_none h1;
+    fresh_is_disjoint (DT.loc dt) (p.local_footprint k) h0 h1;
+    DT.extend dt i k;
     let h2 = get () in
-    lemma_define_tls_honest_regions (p.local_footprint k);
-    p.post_framing #i a k h1 tls_define_region h2;
-    lemma_mm_forall_frame (HS.sel h1 tbl) p.local_invariant ls_footprint ls_footprint_frame tls_define_region h1 h2;
-    p.local_invariant_framing i k h1 tls_define_region h2;
-    lemma_mm_forall_extend (HS.sel h1 tbl) (HS.sel h2 tbl) p.local_invariant i k h1 h2;
-    assume(HS.modifies_ref tls_define_region (Set.singleton (mem_addr (itable mtable))) h0 h2); // How to prove?
-    footprint_grow h0 i k h2;
-    k in
+    p.inv_framing k h1 (DT.loc dt) h2;
+    DT.lemma_footprint_extend dt p.local_footprint i k h1 h2;
+    DT.lemma_forall_extend dt p.inv p.local_footprint p.inv_framing k h1 h2;
+    k
+    in
   [@inline_let]
   let coerce (i:ip.t{ip.registered i /\ (p.ideal ==> ~(ip.honest i))}) (a:p.info i) (k0:lbytes32 (p.len a))
     : ST (p.key i)
-    (requires fun h0 -> package_invariant h0 /\ mem_fresh mtable i h0)
-    (ensures fun h0 k h1 -> k == p.coerceT i a k0
-      /\ modifies_mem_table mtable h0 h1
-      /\ modifies_footprint footprint h0 h1 /\ p.post a k h1
-      /\ package_invariant h1 /\ mem_update mtable i k h0 h1)
+    (requires fun h0 -> package_invariant h0 /\ DT.fresh dt i h0)
+    (ensures fun h0 k h1 -> k == p.coerceT i a k0 /\
+      package_invariant h1 /\
+      (footprint h1) `M.loc_includes` (footprint h0) /\
+      DT.extended dt i k h0 h1)
     =
     if model then (
       let h0 = get () in
-      let tbl : i_mem_table p.key = itable mtable in
-      recall tbl;
+      let t0 = DT.ideal dt in
+      assert_norm(DT.loc dt == (if model then M.loc_mreference t0 else M.loc_none));
+      assert(DT.loc dt == M.loc_mreference t0);
+      recall t0;
+      assert_norm(DT.live dt h0 == (model ==> h0 `HS.contains` (DT.ideal dt)));
       let k : p.key i = p.coerce i a k0 in
       let h1 = get() in
-      assert(HS.sel h0 tbl == HS.sel h1 tbl);
-      package_invariant_framing h0 (Pinv_region tls_tables_region) h1;
-      MDM.extend tbl i k;
+      DT.lemma_footprint_frame dt p.local_footprint h0 h1;
+      DT.lemma_forall_frame dt p.inv p.local_footprint p.inv_framing h0 M.loc_none h1;
+      fresh_is_disjoint (DT.loc dt) (p.local_footprint k) h0 h1;
+      DT.extend dt i k;
       let h2 = get () in
-      lemma_define_tls_honest_regions (p.local_footprint k);
-      p.post_framing #i a k h1 tls_define_region h2;
-      lemma_mm_forall_frame (HS.sel h1 tbl) p.local_invariant ls_footprint ls_footprint_frame tls_define_region h1 h2;
-      p.local_invariant_framing i k h1 tls_define_region h2;
-      lemma_mm_forall_extend (HS.sel h1 tbl) (HS.sel h2 tbl) p.local_invariant i k h1 h2;
-      assume(HS.modifies_ref tls_define_region (Set.singleton (mem_addr (itable mtable))) h0 h2); // How to prove?
-      footprint_grow h0 i k h2;
+      p.inv_framing k h1 (DT.loc dt) h2;
+      DT.lemma_footprint_extend dt p.local_footprint i k h1 h2;
+      DT.lemma_forall_extend dt p.inv p.local_footprint p.inv_framing k h1 h2;
       k
-    ) else p.coerce i a k0
-    in
-  [@inline_let]
-  let post_framing (#i:ip.t{ip.registered i}) (a:p.info i) (k:p.key i)
-    (h0:mem) (r:rid) (h1:mem) : Lemma
-    (requires p.post a k h0 /\ modifies_one r h0 h1 /\ ~(Set.mem r (footprint h0)))
-    (ensures p.post a k h1)
-    =
-    // FIXME(adl): we have a problem when model is false - we have nowhere to store
-    // the joint footprint of the concrete state! for now we will assume
-    // not model ==> local_footprint k = Set.empty for all k
-    // We may have to maintain an erased (i_mem_table p.key) when model is off to
-    // store the concrete footprints
-    assume(~(Set.mem r (footprint h0)) ==> ~(Set.mem r (p.local_footprint k)));
-    p.post_framing #i a k h0 r h1
+    ) else (
+      let h0 = get () in
+      let k = p.coerce i a k0 in
+      let h1 = get() in
+      DT.lemma_footprint_frame dt p.local_footprint h0 h1;
+      DT.lemma_forall_frame dt p.inv p.local_footprint p.inv_framing h0 M.loc_none h1;
+      k
+    )
     in
   (Pkg
     p.key
     p.info
     p.len
     p.ideal
-    mtable footprint footprint_framing
+    dt footprint (DT.lemma_footprint_frame dt p.local_footprint)
     package_invariant package_invariant_framing
-    p.post post_framing
+    (fun #_ _ _ h -> True) (fun #_ _ _ _ _ _ -> ())
     create p.coerceT coerce)
 
-inline_for_extraction
-noextract 
+inline_for_extraction noextract
 let memoization_ST (#ip:ipkg) (p:local_pkg ip)
   : ST (pkg ip)
-  (requires fun h0 -> True)
+  (requires fun h0 -> p.parent `loc_in` h0)
   (ensures fun h0 q h1 ->
     LocalPkg?.key p == Pkg?.key q /\ // seems to help
-    (let t: mem_table p.key = q.define_table in
-    modifies_mem_table t h0 h1 /\
-    q == memoization #ip p t /\
-    q.package_invariant h1))
-=
+    (let dt: DT.dt p.key = q.define_table in
+    M.loc_disjoint (DT.loc dt) p.parent /\
+    q == memoization #ip p dt /\
+    q.package_invariant h1 /\
+    fresh_loc (DT.loc dt) h0 h1))
+  =
   let h0 = get() in
-  let mtable: mem_table p.key = mem_alloc #(i:ip.t{ip.registered i}) p.key in
+  let dt = DT.alloc p.key in
   let h1 = get() in
-  [@inline_let]
-  let q = memoization #ip p mtable in
-  //assert(q == memoization #ip p mtable); // fails when unfolding memoization AR: 12/05: this is no longer needed per the new inlining behavior
-  // assert_norm(q == memoization #ip p mtable);// also fails, with squashing error
-  (if model then lemma_mm_forall_init (HS.sel h1 (itable mtable)) p.local_invariant h1);
+  [@inline_let] let q = memoization #ip p dt in
+  DT.lemma_forall_empty dt p.inv h1;
   q
 
 (*

--- a/src/tls/TLSInfo.fst
+++ b/src/tls/TLSInfo.fst
@@ -61,11 +61,13 @@ let default_groups : (x: CommonDH.supportedNamedGroups { let l = Parsers.NamedGr
   assert_norm (List.Tot.length groups == 7);
   groups
 
-// By default we use an in-memory ticket table
-// and the in-memory internal PSK database
+// We used to have an in-memory ticket table
+// and the in-memory internal PSK database, but
+// these are disabled for thread safety.
 val defaultTicketCBFun: ticket_cb_fun
 let defaultTicketCBFun _ sni ticket info psk =
   let h0 = get() in
+  (* The internal PSK database is obsolete
   begin
   match info with
   | TicketInfo_12 (pv, cs, ems) ->
@@ -80,6 +82,7 @@ let defaultTicketCBFun _ sni ticket info psk =
     PSK.coerce_psk ticket pskInfo psk;      // modifies psk_region
     PSK.extend sni ticket                   // modifies PSK.tregion
   end;
+  *)
   let h1 = HST.get() in
   // 2018.03.10 SZ: [ticket_cb_fun] ensures [modifies_none]
   assume (modifies_none h0 h1)


### PR DESCRIPTION
Updating the security model to use LowStar.Modifies (in preparation for EverCrypt integration)
Also proves difficult assumed lemmas in the proof of the memoization functor