### PR TITLE
Fixes for FStarLang/FStar#1905

### DIFF
--- a/libs/ffi/FFICallbacks.fst
+++ b/libs/ffi/FFICallbacks.fst
@@ -17,14 +17,14 @@ assume val ocaml_recv_tcp: cb_state -> string -> Tot int
 assume val ocaml_ticket_cb: cb_state -> cb_fun_ptr -> string -> bytes -> bytes -> EXT unit
 
 // Certificate callbacks
-assume val ocaml_cert_select_cb: cb_state -> cb_fun_ptr -> pv:int -> sni:string * alpn:bytes -> sigalgs:bytes -> EXT (option (cert_ptr * sigalg))
+assume val ocaml_cert_select_cb: cb_state -> cb_fun_ptr -> pv:int -> (*sni:*)string * (*alpn:*)bytes -> sigalgs:bytes -> EXT (option (cert_ptr * sigalg))
 assume val ocaml_cert_format_cb: cb_state -> cb_fun_ptr -> cert_ptr -> EXT bytes
 assume val ocaml_cert_sign_cb: cb_state -> cb_fun_ptr -> cert_ptr -> sigalg -> tbs:bytes -> EXT (option bytes)
-assume val ocaml_cert_verify_cb: cb_state -> cb_fun_ptr -> bytes -> sigalg -> tbs:bytes * sigv:bytes -> EXT bool
+assume val ocaml_cert_verify_cb: cb_state -> cb_fun_ptr -> bytes -> sigalg -> (*tbs:*)bytes * (*sigv:*)bytes -> EXT bool
 
 (* under the covers, recv invokes String.Substring, which may throw an exception
    due to invalid parameters.  But the recv codepath never does that.  However,
    The F* compiler does not know that.  So implement FFI recv in ML to avoid
    exposing the String.Substring call to effects checking.  Same as
    Platform.Tcp.recv *)
-assume val recvcb: callbacks -> max:nat -> EXT (result:bool * b:string {length (bytes_of_string b) <= max})
+assume val recvcb: callbacks -> max:nat -> EXT ((*result:*)bool * b:string {length (bytes_of_string b) <= max})

--- a/src/tls/AEAD_GCM.fst
+++ b/src/tls/AEAD_GCM.fst
@@ -86,8 +86,8 @@ noeq type state (i:id) (rw:rw) =
 // - gen is called at most once for each (i:id), generating distinct refs for each (i:id)
 // - the log is monotonic
 
-type writer i = s:state i Writer
-type reader i = s:state i Reader
+type writer i = state i Writer
+type reader i = state i Reader
 
 (*
 type matching (#i:id) (r:reader i) (w:writer i) =

--- a/src/tls/Cert.fst
+++ b/src/tls/Cert.fst
@@ -19,8 +19,8 @@ type cert = b:bytes {length b < 16777216}
 type certes = cert * (exts:extensions{length (extensionListBytes exts) < 65536 /\ bindersLen exts == 0})
 // CertificateEntry certificate_list<0..2^24-1>;
 // See https://tlswg.github.io/tls13-spec/#rfc.section.4.4.2
-type chain = l:list cert // { ... }
-type chain13 = l:list certes // { ... }
+type chain = list cert // { ... }
+type chain13 = list certes // { ... }
 
 // we may use these types to keep track of un-extended chains,
 // e.g. to prove that their formatting is injective

--- a/src/tls/CommonDH.fst
+++ b/src/tls/CommonDH.fst
@@ -767,7 +767,7 @@ let parseServerKeyShare b =
   | Correct ks -> Correct (ServerKeyShare ks)
   | Error z -> Error z
 
-let helloRetryKeyShareBytes (k:keyShare): Tot (b:bytes) = 
+let helloRetryKeyShareBytes (k:keyShare): Tot bytes =
   match k with 
   | HRRKeyShare ng -> namedGroup_serializer32 ng
   | _ -> Bytes.empty_bytes 

--- a/src/tls/CommonDH.fsti
+++ b/src/tls/CommonDH.fsti
@@ -61,8 +61,8 @@ val default_group: group
 /// parsing their wire format. This requires checking for collisions
 /// between honestly-generated shares.
 
-type pre_dhi = g:group & s:pre_share g
-type pre_dhr (i:pre_dhi) = s:pre_share (dfst i)
+type pre_dhi = g:group & pre_share g
+type pre_dhr (i:pre_dhi) = pre_share (dfst i)
 
 noextract
 val dh_region : rgn

--- a/src/tls/Crypto.Plain.fst
+++ b/src/tls/Crypto.Plain.fst
@@ -62,12 +62,12 @@ noextract val slice: #i:id -> #l:plainLen -> p:plain i l -> s:nat -> j:nat{s <= 
 let slice #i #l p s j = Seq.slice p s j
 
 
-abstract type plainBuffer (i:id) (l:plainLen) = b:lbuffer l
+abstract type plainBuffer (i:id) (l:plainLen) = lbuffer l
 
 //usage?
 
 // ghost (was named bufferT; no need to be live)
-val as_buffer: #i:id -> #l:plainLen -> pb: plainBuffer i l -> GTot(lbuffer l)
+val as_buffer: #i:id -> #l:plainLen -> pb: plainBuffer i l -> GTot (lbuffer l)
 let as_buffer #i #l pb = pb
 
 // for tests
@@ -116,7 +116,7 @@ let create (i:id) (zero:UInt8.t) (len:UInt32.t) :
 
 let sub #id #l (b:plainBuffer id l)
                (i:UInt32.t{FStar.Buffer.(v i + idx (as_buffer b)) < pow2 n})
-               (len:UInt32.t{FStar.Buffer.(v len <= length (as_buffer b) /\ v i + v len <= length (as_buffer b))}) : Tot (b':plainBuffer id (v len))
+               (len:UInt32.t{FStar.Buffer.(v len <= length (as_buffer b) /\ v i + v len <= length (as_buffer b))}) : Tot (plainBuffer id (v len))
   = Buffer.sub b i len
 // ...
 

--- a/src/tls/Extensions.fst
+++ b/src/tls/Extensions.fst
@@ -70,7 +70,7 @@ let rec binderListBytes_aux (bl:list binder)
       assume (UInt.fits (length b0 + length bt) 32);
       b0 @| bt
 
-val binderListBytes: binders -> Pure (b:bytes)
+val binderListBytes: binders -> Pure bytes
   (requires True)
   (ensures fun b -> length b >= 33 /\ length b <= 65535)
 let binderListBytes bs =
@@ -549,7 +549,7 @@ let is_unknown x =
   x <> twobytes (0x00z, 0x10z)
 
 (* Application extensions *)
-private val ext_of_custom_aux: acc:list extension -> el:custom_extensions -> Tot (l:list extension)
+private val ext_of_custom_aux: acc:list extension -> el:custom_extensions -> Tot (list extension)
 let rec ext_of_custom_aux acc = function
   | [] -> acc
   | (h, b) :: t -> 
@@ -561,7 +561,7 @@ let rec ext_of_custom_aux acc = function
 let ext_of_custom el = List.Tot.rev (ext_of_custom_aux [] el)
 
 #reset-options "--admit_smt_queries true"
-private val custom_of_ext_aux: acc:custom_extensions -> l:list extension -> Tot (el:custom_extensions)
+private val custom_of_ext_aux: acc:custom_extensions -> l:list extension -> Tot custom_extensions
 let rec custom_of_ext_aux acc = function
   | [] -> acc
   | (E_unknown_extension hd b) :: t -> custom_of_ext_aux ((uint16_of_bytes hd, b) :: acc) t

--- a/src/tls/FStar.Old.Endianness.fst
+++ b/src/tls/FStar.Old.Endianness.fst
@@ -35,14 +35,14 @@ let uint128_to_uint8 (a:UInt128.t) : Tot (b:UInt8.t{UInt8.v b = UInt128.v a % po
 open FStar.Seq
 
 (* Little endian integer value of a sequence of bytes *)
-let rec little_endian (b:bytes) : Tot (n:nat) (decreases (Seq.length b)) =
+let rec little_endian (b:bytes) : Tot nat (decreases (Seq.length b)) =
   if Seq.length b = 0 then 0
   else
     UInt8.v (head b) + pow2 8 * little_endian (tail b)
 
 (* Big endian integer value of a sequence of bytes *)
-let rec big_endian (b:bytes) : Tot (n:nat) (decreases (Seq.length b)) = 
-  if Seq.length b = 0 then 0 
+let rec big_endian (b:bytes) : Tot nat (decreases (Seq.length b)) =
+  if Seq.length b = 0 then 0
   else
     UInt8.v (last b) + pow2 8 * big_endian (Seq.slice b 0 (Seq.length b - 1))
 

--- a/src/tls/Format.UncompressedPointRepresentation.fst
+++ b/src/tls/Format.UncompressedPointRepresentation.fst
@@ -84,8 +84,8 @@ let lemma_ucp_of_uv_of_ucp #l
   = lemma_ucp_of_uv_is_injective #l
 #reset-options
 
-let ucp_of_cuv #l (cuv:constantByte 4uy * lbytes_pair l): Tot (ucp:uncompressedPointRepresentation l) = let c, uv = cuv in ucp_of_uv uv
-let cuv_of_ucp #l (ucp:uncompressedPointRepresentation l): Tot (cuv:constantByte 4uy * lbytes_pair l) = 4uy, (ucp.x, ucp.y)
+let ucp_of_cuv #l (cuv:(constantByte 4uy * lbytes_pair l)): Tot (uncompressedPointRepresentation l) = let c, uv = cuv in ucp_of_uv uv
+let cuv_of_ucp #l (ucp:uncompressedPointRepresentation l): Tot (constantByte 4uy * lbytes_pair l) = 4uy, (ucp.x, ucp.y)
 
 #reset-options "--using_facts_from '* -LowParse -FStar.Reflection -FStar.Tactics' --max_fuel 16 --initial_fuel 16 --max_ifuel 16 --initial_ifuel 16"
 let lemma_ucp_of_cuv_is_injective #l

--- a/src/tls/HMAC.UFCMA.fst
+++ b/src/tls/HMAC.UFCMA.fst
@@ -118,7 +118,7 @@ noextract
 val create:
   ip:ipkg -> ha_of_i: (ip.Pkg.t -> ha) -> good_of_i: (i:ip.Pkg.t -> Hashing.macable (ha_of_i i) -> bool) ->
   i:ip.Pkg.t {ip.Pkg.registered i} ->
-  u:info {u.alg = ha_of_i i /\ u.good == good_of_i i} -> ST (k:key ip i)
+  u:info {u.alg = ha_of_i i /\ u.good == good_of_i i} -> ST (key ip i)
   (requires fun _ -> model)
   (ensures fun h0 k h1 ->
     modifies_none h0 h1 /\
@@ -175,7 +175,7 @@ val coerce:
   ip: ipkg -> ha_of_i: (ip.Pkg.t -> ha) -> good_of_i: (i:ip.Pkg.t -> Hashing.macable (ha_of_i i) -> bool) ->
   i: ip.Pkg.t {ip.Pkg.registered i /\ ~(safe i)} ->
   u: info {u.alg = ha_of_i i /\ u.good == good_of_i i} ->
-  kv: lbytes32 (keylen u) -> ST (k:key ip i)
+  kv: lbytes32 (keylen u) -> ST (key ip i)
   (requires fun _ -> True)
   (ensures fun h0 k h1 ->
     modifies_none h0 h1 /\

--- a/src/tls/HandshakeLog.fst
+++ b/src/tls/HandshakeLog.fst
@@ -107,7 +107,7 @@ let rec gforall_list_to_list_refined
   (#a: Type)
   (f: (a -> GTot bool))
   (l: list a { gforall f l } )
-: Tot (l': list (x: a {f x}))
+: Tot (list (x: a {f x}))
 = match l with
   | [] -> []
   | x :: q -> x :: gforall_list_to_list_refined f q

--- a/src/tls/HandshakeMessages.fst
+++ b/src/tls/HandshakeMessages.fst
@@ -1523,9 +1523,9 @@ let rec handshakeMessagesBytes pv = function
 
 //#reset-options
 
-let lemma_handshakeMessagesBytes_def (pv:option protocolVersion) (li:list (msg:valid_hs_msg pv){Cons? li}) : Lemma (handshakeMessagesBytes pv li = ((handshakeMessageBytes pv (Cons?.hd li)) @| (handshakeMessagesBytes pv (Cons?.tl li)))) = ()
+let lemma_handshakeMessagesBytes_def (pv:option protocolVersion) (li:list (valid_hs_msg pv){Cons? li}) : Lemma (handshakeMessagesBytes pv li = ((handshakeMessageBytes pv (Cons?.hd li)) @| (handshakeMessagesBytes pv (Cons?.tl li)))) = ()
 
-let lemma_handshakeMessagesBytes_def2 (pv:option protocolVersion) (li:list (msg:valid_hs_msg pv){Nil? li}) : Lemma (handshakeMessagesBytes pv li = empty_bytes) = ()
+let lemma_handshakeMessagesBytes_def2 (pv:option protocolVersion) (li:list (valid_hs_msg pv){Nil? li}) : Lemma (handshakeMessagesBytes pv li = empty_bytes) = ()
 
 val lemma_handshakeMessageBytes_aux: pv:option protocolVersion -> msg1:valid_hs_msg pv -> msg2:valid_hs_msg pv ->
   Lemma (requires (let b1 = handshakeMessageBytes pv msg1 in
@@ -1581,7 +1581,7 @@ let lemma_aux_1 (a:bytes) (b:bytes) (c:bytes) (d:bytes) : Lemma
 
 let lemma_handshakeMessageBytes_min_length (pv:option protocolVersion) (msg:valid_hs_msg pv) : Lemma (length (handshakeMessageBytes pv msg) >= 4) = ()
 
-let lemma_aux_2 (pv:option protocolVersion) (l:list (msg:valid_hs_msg pv)) :
+let lemma_aux_2 (pv:option protocolVersion) (l:list (valid_hs_msg pv)) :
   Lemma (requires (Cons? l))
   (ensures (length (handshakeMessagesBytes pv l) > 0))
   = ()

--- a/src/tls/HandshakeMessages.fsti
+++ b/src/tls/HandshakeMessages.fsti
@@ -146,7 +146,7 @@ noeq type ske = {
   ske_kex_s: kex_s;
   ske_signed_params: signature }
 
-type cv = sig:signature
+type cv = signature
 
 //17-03-11 Finished payload, carrying a fixed-length MAC; share with binders?
 type fin = { fin_vd: b:bytes{length b < 65536}; }
@@ -166,7 +166,7 @@ noeq type sticket13 = {
   ticket13_age_add: UInt32.t;
   ticket13_nonce: (b:bytes{length b > 0 /\ length b < 256});
   ticket13_ticket: (b:bytes{length b < 65535});
-  ticket13_extensions: es: list extension; }
+  ticket13_extensions: list extension; }
 
 
 noeq type hs_msg =
@@ -300,7 +300,7 @@ val serverHelloBytes_is_injective_strong:
 (* JK: should return a valid_sh to match the serialization function *)
 (* JK: same as parseClientHello, weakening spec to get verification *)
 val parseServerHello:
-  data:bytes{repr_bytes(length data) <= 3} -> Tot (result (x:valid_sh))
+  data:bytes{repr_bytes(length data) <= 3} -> Tot (result valid_sh)
 (* val parseServerHello: data:bytes{repr_bytes(length data) <= 3}   *)
 (*   -> Tot (result (x:sh{equal (serverHelloBytes x) (messageBytes HT_server_hello data)})) *)
 
@@ -372,14 +372,14 @@ val handshakeMessageBytes_is_injective:
   (requires equal (handshakeMessageBytes pv msg1) (handshakeMessageBytes pv msg2))
   (ensures msg1 == msg2)
 
-val handshakeMessagesBytes: pv:option protocolVersion -> list (msg:valid_hs_msg pv) -> bytes
+val handshakeMessagesBytes: pv:option protocolVersion -> list (valid_hs_msg pv) -> bytes
 // we may need to expose its definition to HandshakeLog
 
 #set-options "--admit_smt_queries true"
 val handshakeMessagesBytes_is_injective:
   pv: option protocolVersion -> 
-  l1: list (msg:valid_hs_msg pv) -> 
-  l2: list (msg:valid_hs_msg pv) -> Lemma 
+  l1: list (valid_hs_msg pv) ->
+  l2: list (valid_hs_msg pv) -> Lemma
   (requires equal (handshakeMessagesBytes pv l1) (handshakeMessagesBytes pv l2))
   (ensures l1 = l2)
 #reset-options

--- a/src/tls/Mem.fst
+++ b/src/tls/Mem.fst
@@ -141,7 +141,7 @@ private let p :
 
 // consider dropping the tls_ prefix
 noextract
-let tls_tables_region: r:tls_rgn =
+let tls_tables_region: tls_rgn =
   match p with | (| r, _, _ |) -> r
 
 noextract

--- a/src/tls/Negotiation.fst
+++ b/src/tls/Negotiation.fst
@@ -1173,7 +1173,7 @@ val compute_cs13:
   psks: list (PSK.pskid * PSK.pskInfo) ->
   shares: list share (* pre-registered *) ->
   server_cert: bool (* is a certificate available for signing? *) ->
-  result (list (cs13 o) * option (CommonDH.namedGroup * cs:cipherSuite))
+  result (list (cs13 o) * option (CommonDH.namedGroup * cipherSuite))
 let compute_cs13 cfg o psks shares server_cert =
   // pick acceptable record ciphersuites
   let ncs = filter_cipherSuites13 cfg o.ch_cipher_suites in

--- a/src/tls/Old.Epochs.fst
+++ b/src/tls/Old.Epochs.fst
@@ -71,7 +71,7 @@ noeq type epoch (hs_rgn:rgn) (n:random) =
       h :Negotiation.handshake ->
       r: reader (peerId i) ->
       w: writer i {epoch_region_inv' hs_rgn r w} ->
-      pn: option bytes * option bytes ->
+      pn: (option bytes * option bytes) ->
       epoch hs_rgn n
 
 // we would extend/adapt it for TLS 1.3,
@@ -178,7 +178,7 @@ let containsT (#r:rgn) (#n:random) (es:epochs r n) (h:mem) =
     MS.i_contains (MkEpochs?.es es) h
 
 val alloc_log_and_ctrs: #a:Type0 -> #p:(seq a -> Type0) -> r:rgn ->
-  ST (is:MS.i_seq r a p & c1:epoch_ctr r is & c2:epoch_ctr r is)
+  ST (is:MS.i_seq r a p & c1:epoch_ctr r is & (*c2:*)epoch_ctr r is)
     (requires (fun h -> p Seq.empty))
     (ensures (fun h0 x h1 ->
       modifies_one r h0 h1 /\

--- a/src/tls/PSK.fst
+++ b/src/tls/PSK.fst
@@ -31,7 +31,7 @@ let extend (h:hostname) (t:tlabel h) = MDM.extend tickets h t
 
 // SESSION TICKET DATABASE (TLS 1.2)
 // Note that this table also stores the master secret
-type session12 (tid:bytes) = protocolVersion * cipherSuite * ems:bool * ms:bytes
+type session12 (tid:bytes) = protocolVersion * cipherSuite * (*ems:*)bool * (*ms:*)bytes
 private let sessions12 : MDM.t tregion bytes session12 (fun _ -> True) =
   MDM.alloc ()
 

--- a/src/tls/Parse.fst
+++ b/src/tls/Parse.fst
@@ -45,7 +45,7 @@ let vlbytes2 (b:bytes {length b < pow2 16}) = lemma_repr_bytes_values (length b)
 val vlbytes_trunc: 
   lSize:nat {lSize <= 3} -> b:bytes -> 
   extra:nat {repr_bytes (length b + extra) <= lSize} ->
-  r: lbytes (lSize + length b)
+  lbytes (lSize + length b)
 let vlbytes_trunc lSize b extra =
   bytes_of_int lSize (length b + extra) @| b
 

--- a/src/tls/Range.fst
+++ b/src/tls/Range.fst
@@ -117,7 +117,7 @@ let valid_clen (i:id) (clen:nat) =
       clen - UInt32.v (hashLen h) <= max_TLSPlaintext_fragment_length
     end)
 
-let min0 (i:int) : Tot (n:nat) = if i >= 0 then i else 0
+let min0 (i:int) : Tot nat = if i >= 0 then i else 0
 let minP (n:int) : Tot (m:int{m <= n /\ m <= max_TLSPlaintext_fragment_length}) =
   if n >= max_TLSPlaintext_fragment_length then max_TLSPlaintext_fragment_length
   else n

--- a/src/tls/Record.fst
+++ b/src/tls/Record.fst
@@ -48,7 +48,7 @@ private let parseVersion (x: lbytes 2) = parseVersion (p_of_f x)
 
 private let headerLen = 5ul 
 private (* noextract *) let headerLength = v headerLen 
-private type header = b:lbytes headerLength // for all TLS versions
+private type header = lbytes headerLength // for all TLS versions
 
 #reset-options "--using_facts_from '* -LowParse.Spec.Base'"
 

--- a/src/tls/StAE.fst
+++ b/src/tls/StAE.fst
@@ -425,7 +425,7 @@ let fragment_at_j_stable (#i:id) (#rw:rw) (s:state i rw{authId i}) (n:nat) (f:C.
 
 
 val decrypt: #i:id -> d:reader i -> c:C.decrypted i
-  -> ST (option (f:C.fragment i))
+  -> ST (option (C.fragment i))
     (requires (fun h0 -> incrementable d h0))
     (ensures  (fun h0 res h1 ->
    	        match res with

--- a/src/tls/StreamAE.fst
+++ b/src/tls/StreamAE.fst
@@ -89,8 +89,8 @@ noeq type state (i:id) (rw:rw) =
 // - gen is called at most once for each (i:id), generating distinct refs for each (i:id)
 // - the log is monotonic
 
-type writer i = s:state i Writer
-type reader i = s:state i Reader
+type writer i = state i Writer
+type reader i = state i Reader
 
 #set-options "--admit_smt_queries true"
 

--- a/src/tls/StreamPlain.fst
+++ b/src/tls/StreamPlain.fst
@@ -44,7 +44,7 @@ val pad_zeros: payload:bytes
 let pad_zeros payload ct len len' = ()
 *)
 #set-options "--z3rlimit 100 --max_ifuel 1 --initial_ifuel 0 --max_fuel 1 --initial_fuel 0"
-val ghost_repr: #i:id -> #len: plainLen -> f:plain i len -> GTot (bs:lbytes len)
+val ghost_repr: #i:id -> #len: plainLen -> f:plain i len -> GTot (lbytes len)
 let ghost_repr #i #len f =
   let ct,_ = ct_rg i f in
   let payload = Content.ghost_repr #i f in

--- a/src/tls/TLSConstants.fst
+++ b/src/tls/TLSConstants.fst
@@ -645,7 +645,7 @@ type pskInfo = {
 }
 
 type ticketInfo =
-  | TicketInfo_12 of protocolVersion * cipherSuite * ems:bool
+  | TicketInfo_12 of protocolVersion * cipherSuite * (*ems:*)bool
   | TicketInfo_13 of pskInfo
 
 type ticket_seal = b:bytes{length b < 65536}

--- a/src/tls/TLSInfo.fst
+++ b/src/tls/TLSInfo.fst
@@ -181,7 +181,7 @@ type sessionID = b:bytes { length b <= 32 }
 noeq type sessionInfo = {
     init_crand: crand;
     init_srand: srand;
-    protocol_version: p:protocolVersion; // { p <> TLS_1p3 };
+    protocol_version: protocolVersion; // p:protocolVersion{ p <> TLS_1p3 };
     cipher_suite: cipherSuite;
     compression: compression;
     extended_ms: bool;
@@ -337,15 +337,15 @@ type logInfo_CH = {
 type logInfo_CH0 = {
   li_ch0_cr: crand;
   li_ch0_ed_psk: PSK.pskid;   // 0-RT PSK
-  li_ch0_ed_ae: a:aeadAlg;    // 0-RT AEAD alg
-  li_ch0_ed_hash: h:hash_alg; // 0-RT hash
+  li_ch0_ed_ae: aeadAlg;      // 0-RT AEAD alg
+  li_ch0_ed_hash: hash_alg;   // 0-RT hash
 }
 
 type logInfo_SH = {
   li_sh_cr: crand;
   li_sh_sr: srand;
-  li_sh_ae: a:aeadAlg;        // AEAD alg selected by the server
-  li_sh_hash: h:hash_alg;     // Handshake hash selected by the server
+  li_sh_ae: aeadAlg;          // AEAD alg selected by the server
+  li_sh_hash: hash_alg;       // Handshake hash selected by the server
   li_sh_psk: option PSK.pskid;// PSK selected by the server
 }
 
@@ -366,7 +366,7 @@ type logInfo =
 | LogInfo_SF of logInfo_SF
 | LogInfo_CF of logInfo_CF
 
-let logInfo_ae : x:logInfo{~(LogInfo_CH? x)} -> Tot (a:aeadAlg) = function
+let logInfo_ae : x:logInfo{~(LogInfo_CH? x)} -> Tot aeadAlg = function
 | LogInfo_CH0 x -> x.li_ch0_ed_ae
 | LogInfo_SH x -> x.li_sh_ae
 | LogInfo_SF x -> x.li_sf_sh.li_sh_ae

--- a/src/tls/Ticket.fst
+++ b/src/tls/Ticket.fst
@@ -27,7 +27,7 @@ unfold let trace = if DebugFlags.debug_NGO then print else (fun _ -> ())
 
 // verification-only
 type hostname = string
-type tlabel (h:hostname) = t:bytes * tls13:bool
+type tlabel (h:hostname) = (*t:*)bytes * (*tls13:*)bool
 
 noextract
 private let region:rgn = new_region tls_tables_region

--- a/src/tls/Token.UF1CMA.fst
+++ b/src/tls/Token.UF1CMA.fst
@@ -105,7 +105,7 @@ let footprint (#ip:ipkg) (#i:ip.Pkg.t {ip.Pkg.registered i}) (k:key ip i):
 val create:
   ip:ipkg -> ha_of_i: (ip.Pkg.t -> ha) -> good_of_i: (ip.Pkg.t -> bool) ->
   i:ip.Pkg.t {ip.Pkg.registered i} ->
-  u:info {u.alg = ha_of_i i /\ u.good == good_of_i i} -> ST (k:key ip i)
+  u:info {u.alg = ha_of_i i /\ u.good == good_of_i i} -> ST (key ip i)
   (requires fun _ -> model)
   (ensures fun h0 k h1 ->
     modifies Set.empty h0 h1 /\
@@ -145,7 +145,7 @@ val coerce:
   ip: ipkg -> ha_of_i: (ip.Pkg.t -> ha) -> good_of_i: (ip.Pkg.t -> bool) ->
   i: ip.Pkg.t {ip.Pkg.registered i /\ ~(safe i)} ->
   u: info {u.alg = ha_of_i i /\ u.good == good_of_i i} ->
-  kv: lbytes32 (keylen u) -> ST (k:key ip i)
+  kv: lbytes32 (keylen u) -> ST (key ip i)
   (requires fun _ -> True)
   (ensures fun h0 k h1 ->
     modifies_none h0 h1 /\


### PR DESCRIPTION
This PR fixes spurious uses of names, as described in FStarLang/FStar#1905. F* will reject these names with a syntax error once the fix is merged (waiting on this PR and one in Everparse).