### PR TITLE
Freebsd

### DIFF
--- a/apps/QuicWin/QuicWin/QuicWin.cpp
+++ b/apps/QuicWin/QuicWin/QuicWin.cpp
@@ -8,7 +8,10 @@ extern "C" {
 #include <assert.h>
 #include <sys/stat.h>
 #include <errno.h>
+#if __FreeBSD__
+#else
 #include <malloc.h>
+#endif
 
 void dump(unsigned char buffer[], size_t len) {
     int i;

--- a/apps/cmitls/Makefile
+++ b/apps/cmitls/Makefile
@@ -37,6 +37,14 @@ else ifeq ($(UNAME),Linux)
   LIBPATHS=$(EVERCRYPT_HOME)/../dist/mitls:$(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(MLCRYPTO_HOME)/openssl
   LD_LIBRARY_PATH := $(LIBPATHS):$(LD_LIBRARY_PATH)
   export LD_LIBRARY_PATH
+else ifeq ($(UNAME),FreeBSD)
+  LIBMITLS=libmitls.so
+  LIBPKI=libmipki.so
+  PIC=-fPIC -lpthread
+  WINSOCK=
+  LIBPATHS=$(EVERCRYPT_HOME)/../dist/mitls:$(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(MLCRYPTO_HOME)/openssl
+  LD_LIBRARY_PATH := $(LIBPATHS):$(LD_LIBRARY_PATH)
+  export LD_LIBRARY_PATH
 endif
 
 all: cmitls.exe

--- a/apps/cmitls/benchmark.sh
+++ b/apps/cmitls/benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -f results
 

--- a/apps/cmitls/cmitls.c
+++ b/apps/cmitls/cmitls.c
@@ -11,7 +11,10 @@ typedef int socklen_t;
 #include <sys/socket.h>
 #include <netdb.h>
 #include <errno.h>
+#if __FreeBSD__
+#else
 #include <alloca.h>
+#endif
 #define _alloca alloca
 typedef int SOCKET;
 #define SOCKET_ERROR (-1)

--- a/apps/quicMinusNet/Makefile
+++ b/apps/quicMinusNet/Makefile
@@ -40,6 +40,14 @@ else ifeq ($(UNAME),Linux)
   LIBPATHS=$(EVERCRYPT_HOME)/../dist/mitls:$(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(HACL_HOME)/providers/quic_provider:$(MLCRYPTO_HOME)/openssl
   LD_LIBRARY_PATH := $(LIBPATHS):$(LD_LIBRARY_PATH)
   export LD_LIBRARY_PATH
+else ifeq ($(UNAME),FreeBSD)
+  LIBMITLS=libmitls.so
+  LIBQC=libquiccrypto.so
+  LIBPKI=libmipki.so
+  CFLAGS+=-lpthread -pthread
+  LIBPATHS=$(EVERCRYPT_HOME)/../dist/mitls:$(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(HACL_HOME)/providers/quic_provider:$(MLCRYPTO_HOME)/openssl
+  LD_LIBRARY_PATH := $(LIBPATHS):$(LD_LIBRARY_PATH)
+  export LD_LIBRARY_PATH
 endif
 
 all: quic.exe

--- a/apps/quicMinusNet/quic.c
+++ b/apps/quicMinusNet/quic.c
@@ -9,7 +9,10 @@
 #include <sys/errno.h> // OS/X only provides include/sys/errno.h
 #else
 #include <errno.h> // MinGW only provides include/errno.h
+#if __FreeBSD__
+#else
 #include <malloc.h>
+#endif
 #endif
 
 // TLS library

--- a/libs/ffi/ffi.c
+++ b/libs/ffi/ffi.c
@@ -7,7 +7,10 @@
 #include <sys/errno.h> // OS/X only provides include/sys/errno.h
 #else
 #include <errno.h> // MinGW only provides include/errno.h
+#if __FreeBSD__
+#else
 #include <malloc.h>
+#endif
 #endif
 #include <caml/callback.h>
 #include <caml/alloc.h>

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   sudo /etc/init.d/postgresql stop;

--- a/scripts/vsbin.sh
+++ b/scripts/vsbin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Starting from Visual Studio 2017, version 15.2 or later,
 # we can determine the location of a VS install
 # using vswhere.exe, see:

--- a/src/tls/Makefile
+++ b/src/tls/Makefile
@@ -10,7 +10,7 @@ clean-depend:
 refresh-depend: clean-depend
 	+$(MAKE) -C ../parsers gen
 
-SHELL=/bin/bash
+SHELL:=$(shell which bash)
 
 .PHONY: clean-%
 clean-c:

--- a/src/tls/Makefile.Kremlin
+++ b/src/tls/Makefile.Kremlin
@@ -55,6 +55,8 @@ ifeq ($(UNAME),Darwin)
   VARIANT=-Darwin
 else ifeq ($(UNAME),Linux)
   VARIANT=-Linux
+else ifeq ($(UNAME),FreeBSD)
+  VARIANT=-FreeBSD
 endif
 
 ################################################################################

--- a/src/tls/Makefile.OCaml
+++ b/src/tls/Makefile.OCaml
@@ -219,6 +219,8 @@ else ifeq ($(UNAME),Darwin)
   PREFIX = DYLD_LIBRARY_PATH=$(MLCRYPTO_HOME)/openssl:$(EVERCRYPT_HOME)/out:$(MITLS_HOME)/src/pki:$(DYLD_LIBRARY_PATH)
 else ifeq ($(UNAME),Linux)
   export LD_LIBRARY_PATH := $(MLCRYPTO_HOME)/openssl:$(EVERCRYPT_HOME)/out:$(MITLS_HOME)/src/pki:$(LD_LIBRARY_PATH)
+else ifeq ($(UNAME),FreeBSD)
+  export LD_LIBRARY_PATH := $(MLCRYPTO_HOME)/openssl:$(EVERCRYPT_HOME)/out:$(MITLS_HOME)/src/pki:$(LD_LIBRARY_PATH)
 endif
 
 test: mitls.exe $(CERT_FILES)

--- a/src/tls/Makefile.common
+++ b/src/tls/Makefile.common
@@ -13,7 +13,7 @@ ifndef LOWPARSE_HOME
 endif
 FLAVOR          ?= Model
 
-SHELL=/bin/bash
+SHELL:=$(shell which bash)
 
 include $(HACL_HOME)/Makefile.include
 

--- a/src/tls/artifact.sh
+++ b/src/tls/artifact.sh
@@ -1,4 +1,4 @@
- #!/bin/bash
+ #!/usr/bin/env bash
 set -e
 # Any subsequent(*) commands which fail will cause the shell script to exit immediately
 

--- a/src/tls/extract/Kremlin-Internal-Test/Makefile
+++ b/src/tls/extract/Kremlin-Internal-Test/Makefile
@@ -33,6 +33,12 @@ else ifeq ($(UNAME),Linux)
   LDOPTS += -lpthread
   SO = so
   export LD_LIBRARY_PATH
+else ifeq ($(UNAME),FreeBSD)
+  VARIANT = -FreeBSD
+  LD_LIBRARY_PATH := $(EVERCRYPT_HOME)/../dist/mitls:$(MITLS_HOME)/src/pki:$(LD_LIBRARY_PATH)
+  LDOPTS += -lpthread
+  SO = so
+  export LD_LIBRARY_PATH
 endif
 
 ifeq (,$(wildcard $(MITLS_HOME)/src/pki/libmipki.$(SO)))

--- a/src/tls/extract/Kremlin-Library/Makefile
+++ b/src/tls/extract/Kremlin-Library/Makefile
@@ -31,6 +31,13 @@ else ifeq ($(UNAME),Linux)
   LDOPTS := -lpthread -Xlinker -z -Xlinker noexecstack -Xlinker --version-script -Xlinker $(MITLS_HOME)/src/tls/libmitls_version_script -Wl,-z,defs $(LDOPTS)
   SO = so
   export LD_LIBRARY_PATH
+else ifeq ($(UNAME),FreeBSD)
+  VARIANT = -FreeBSD
+  CFLAGS := -fPIC $(CFLAGS)
+  LD_LIBRARY_PATH :=  $(MITLS_HOME)/src/pki:$(LD_LIBRARY_PATH)
+  LDOPTS := -lpthread -Xlinker -z -Xlinker noexecstack -Xlinker --version-script -Xlinker $(MITLS_HOME)/src/tls/libmitls_version_script -Wl,-z,defs $(LDOPTS)
+  SO = so
+  export LD_LIBRARY_PATH
 endif
 
 # Force-include RegionAllocator.h and enable heap regions in all builds

--- a/src/tls/extract/Kremlin-Msvc-Library/Makefile
+++ b/src/tls/extract/Kremlin-Msvc-Library/Makefile
@@ -31,6 +31,13 @@ else ifeq ($(UNAME),Linux)
   LDOPTS := -lpthread -Xlinker -z -Xlinker noexecstack -Xlinker --version-script -Xlinker $(MITLS_HOME)/src/tls/libmitls_version_script -Wl,-z,defs $(LDOPTS)
   SO = so
   export LD_LIBRARY_PATH
+else ifeq ($(UNAME),FreeBSD)
+  VARIANT = -FreeBSD
+  CFLAGS := -fPIC $(CFLAGS)
+  LD_LIBRARY_PATH :=  $(MITLS_HOME)/src/pki:$(LD_LIBRARY_PATH)
+  LDOPTS := -lpthread -Xlinker -z -Xlinker noexecstack -Xlinker --version-script -Xlinker $(MITLS_HOME)/src/tls/libmitls_version_script -Wl,-z,defs $(LDOPTS)
+  SO = so
+  export LD_LIBRARY_PATH
 endif
 
 # Force-include RegionAllocator.h and enable heap regions in all builds

--- a/src/tls/extract/cstubs/RegionAllocator.c
+++ b/src/tls/extract/cstubs/RegionAllocator.c
@@ -4,7 +4,10 @@
 #include <sys/errno.h> // OS/X only provides include/sys/errno.h
 #include <stdlib.h>
 #else
+#if __FreeBSD__
+#else
 #include <malloc.h>
+#endif
 #include <errno.h> // MinGW only provides include/errno.h
 #endif
 #if defined(_MSC_VER)

--- a/src/tls/extract/cstubs/mitlsffi.c
+++ b/src/tls/extract/cstubs/mitlsffi.c
@@ -4,7 +4,10 @@
 #include <sys/errno.h> // OS/X only provides include/sys/errno.h
 #else
 #include <errno.h> // MinGW only provides include/errno.h
+#if __FreeBSD__
+#else
 #include <malloc.h>
+#endif
 #endif
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #define IS_WINDOWS 1

--- a/src/tls/renamings.sh
+++ b/src/tls/renamings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## This script applies the renamings described above to all *fst and
 ## *fsti files in the current directory.


### PR DESCRIPTION
These changes replace a few Linux-isms (e.g. /bin/bash) with portable usage, resolve header-file conflicts, and set build options per uname on FreeBSD.