### PR TITLE
Fix shadowing of Parse module by FStar.Parse

### DIFF
--- a/src/tls/Alert.fst
+++ b/src/tls/Alert.fst
@@ -8,6 +8,7 @@ open FStar.Bytes
 open TLSError
 open TLSConstants
 open TLSInfo
+module Parse = Parse
 open Parse
 open Mem
 

--- a/src/tls/Cert.fst
+++ b/src/tls/Cert.fst
@@ -7,6 +7,7 @@ open FStar.Error
 open TLSError
 open TLSConstants
 open Extensions // defining cert, cert13, chain
+module Parse = Parse
 open Parse
  
 let rec certificateListBytes = function

--- a/src/tls/Cert.fsti
+++ b/src/tls/Cert.fsti
@@ -7,7 +7,7 @@ open FStar.Error
 open TLSError
 open TLSConstants
 open Extensions // defining cert, cert13, chain
-open Parse
+module Parse = Parse
  
 (* The chain format changes between TLS 1.2 and TLS 1.3; we separate
 then in messages, but at least for now, we merge the two in

--- a/src/tls/CipherSuite.fsti
+++ b/src/tls/CipherSuite.fsti
@@ -7,7 +7,7 @@ open FStar.Error
 open TLSError
 
 open Mem
-open Parse
+module Parse = Parse
 //include Parse
 
 

--- a/src/tls/CommonDH.fst
+++ b/src/tls/CommonDH.fst
@@ -12,7 +12,7 @@ share is for registered shares (for which is_honest is defined).
 open FStar.Bytes
 open FStar.Error
 
-open Parse
+module Parse = Parse
 open TLSError
 open Mem 
 

--- a/src/tls/CommonDH.fsti
+++ b/src/tls/CommonDH.fsti
@@ -12,6 +12,7 @@ module CommonDH
 open FStar.HyperStack
 open FStar.Bytes
 open FStar.Error
+module Parse = Parse
 open Parse
 open TLSError
 open FStar.HyperStack.ST

--- a/src/tls/Content.fst
+++ b/src/tls/Content.fst
@@ -14,6 +14,7 @@ open TLSConstants
 open TLSInfo
 open Range
 open DataStream
+module Parse = Parse
 open Parse
 module Range = Range
 

--- a/src/tls/DHGroup.fst
+++ b/src/tls/DHGroup.fst
@@ -5,7 +5,7 @@ open FStar.Error
 
 open TLSError
 open Mem
-open Parse
+module Parse = Parse
 
 module LP = LowParse.SLow
 

--- a/src/tls/ECGroup.fst
+++ b/src/tls/ECGroup.fst
@@ -3,6 +3,7 @@ module ECGroup
 open FStar.Error
 open TLSError
 open Mem
+module Parse = Parse
 open Parse
 
 module B = FStar.Bytes

--- a/src/tls/Extensions.fst
+++ b/src/tls/Extensions.fst
@@ -14,6 +14,7 @@ open FStar.Error
 
 open TLSError
 open TLSConstants
+module Parse = Parse
 open Parse
 
 #set-options "--initial_fuel 2 --max_fuel 2 --initial_ifuel 1 --max_ifuel 1 --z3rlimit 10"

--- a/src/tls/FFI.fst
+++ b/src/tls/FFI.fst
@@ -21,6 +21,7 @@ open TLSConstants
 open TLSInfo
 module Range = Range
 open Range
+module Parse = Parse
 
 open Mem
 open DataStream

--- a/src/tls/HandshakeLog.fst
+++ b/src/tls/HandshakeLog.fst
@@ -14,6 +14,7 @@ open Hashing
 open Hashing.CRF // now using incremental, collision-resistant, agile Hashing.
 open FStar.Bytes //18-08-31 reordered 
 open Range  // cwinter: the extracted OCaml file contains a reference to this, which is not reflected in the .depend file?
+module Parse = Parse
 
 module HS = FStar.HyperStack
 

--- a/src/tls/HandshakeMessages.fsti
+++ b/src/tls/HandshakeMessages.fsti
@@ -12,6 +12,7 @@ open Extensions
 open TLSInfo
 open Range
 open CommonDH
+module Parse = Parse
 open Parse
 
 // e18-02-21 carved out an interface, far from perfect...

--- a/src/tls/LHAEPlain.fst
+++ b/src/tls/LHAEPlain.fst
@@ -7,6 +7,7 @@ open FStar.Error
 open TLSError
 open TLSConstants
 open TLSInfo
+module Parse = Parse
 open Parse
 
 module Range = Range

--- a/src/tls/Old.Handshake.fsti
+++ b/src/tls/Old.Handshake.fsti
@@ -7,6 +7,7 @@ module HS = FStar.HyperStack
 module Range = Range
 module Epochs = Old.Epochs
 module KeySchedule = Old.KeySchedule
+module Parse = Parse
 
 #set-options "--admit_smt_queries true"
 

--- a/src/tls/QUIC.fst
+++ b/src/tls/QUIC.fst
@@ -26,6 +26,7 @@ module HS = FStar.HyperStack
 module FFI = FFI
 module Range = Range
 open Range
+module Parse = Parse
 
 #set-options "--admit_smt_queries true"
 

--- a/src/tls/TLSConstants.fst
+++ b/src/tls/TLSConstants.fst
@@ -29,7 +29,7 @@ open FStar.Error
 open TLSError
 
 open Mem
-open Parse
+module Parse = Parse
 //include Parse
 
 (*

--- a/src/tls/TLSConstants.fsti
+++ b/src/tls/TLSConstants.fsti
@@ -29,6 +29,7 @@ open FStar.Error
 open TLSError
 
 open Mem
+module Parse = Parse
 open Parse
 //include Parse
 

--- a/src/tls/Ticket.fst
+++ b/src/tls/Ticket.fst
@@ -4,6 +4,7 @@ open FStar.Bytes
 open FStar.Error
 
 open Mem
+module Parse = Parse
 open Parse
 open TLSError
 open TLSConstants

--- a/src/tls/test/TestKS.fst
+++ b/src/tls/test/TestKS.fst
@@ -4,7 +4,7 @@ open FStar.HyperHeap
 
 open Platform.Bytes
 open TLSConstants
-open Parse
+module Parse = Parse
 
 module CDH = CommonDH
 module CC = CoreCrypto

--- a/src/tls/test/parsing_test.ml
+++ b/src/tls/test/parsing_test.ml
@@ -4,7 +4,7 @@ open Platform.Error
 open HandshakeMessages
 open TLSError
 open TLSConstants
-open Parse
+module Parse = Parse
 
 (* State variables *)
 let pv = ref TLS_1p2


### PR DESCRIPTION
Use the `module Parse = Parse` idiom. See:
- https://github.com/FStarLang/FStar/issues/1465
- https://github.com/FStarLang/FStar/pull/1323

--

This should fix the everest build