### PR TITLE
Switch to upstream EverParse `fstar2` (fits_u64‑free LowParse), add a CI pipeline

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,6 +27,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 #   python3                   - agentic-tls test scripts (port picker, payload gen)
 #   tftp-hpa,tftpd-hpa         - TFTP reference client (tftp) / server (in.tftpd)
 #                               for the tftp_sample interop tests (RFC 1350)
+#   lrzsz                     - XMODEM/YMODEM/ZMODEM reference client/server (sb/rb)
+#                               for the ymodem_sample interop tests
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       time \
@@ -44,6 +46,7 @@ RUN apt-get update \
       python3 \
       tftp-hpa \
       tftpd-hpa \
+      lrzsz \
       libcap2-bin \
  && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -69,4 +69,4 @@ WORKDIR /home/vscode
 
 # Put F*, Z3, and QD on the PATH
 RUN ep=/workspaces/agentic-tls/tools/everparse/; \
-  echo "export PATH=$ep/opt/FStar/out/bin:$ep/opt/FStar/karamel/out/bin:$ep/bin:$ep/opt/z3:\$PATH" | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
+  echo "export PATH=$ep/opt/FStar/out/bin:$ep/opt/karamel/out/bin:$ep/bin:$ep/opt/z3:\$PATH" | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,6 +15,7 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Minimal apt set:
+#   time                      - build Karamel
 #   ca-certificates,curl,git  - fetch the EverParse fork, HACL* submodule, RFCs, Z3
 #   opam                      - drives the local OCaml switch for the F*/KaRaMeL build
 #   build-essential           - gcc/make for the OCaml build and the agentic-tls C code
@@ -28,6 +29,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 #                               for the tftp_sample interop tests (RFC 1350)
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
+      time \
       ca-certificates \
       curl \
       git \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,13 @@ jobs:
   # injecting it leaves the cached toolchain and fetched RFCs untouched.
   # fail-fast: false so every target reports independently; the ci-success gate
   # still needs all of them.
+  #
+  # The tls-root leg additionally caches the F* verification of the generated
+  # TLS13.Wire.Generated.* parsers/serializers (a ~9-min step).  Those .checked
+  # files are a pure function of the wire spec (tls.qd.rfc) and the pinned
+  # toolchain (scripts/build-everparse.sh), so the cache is keyed on the hash of
+  # exactly those two files; the Makefile save-/restore-generated-cache targets
+  # export/import them as a single tarball moved in/out of the container.
   tests:
     name: ${{ matrix.name }}
     needs: devcontainer
@@ -96,6 +103,7 @@ jobs:
         include:
           - name: tls-root (make test)
             cmd: make -j"$(nproc)" _cache/TLS13.Impl.Driver.PairingNoTailStagedBoundaryDerivation.fst.checked && make -j"$(nproc)" test
+            cache_generated: true
           - name: calc (test-c)
             cmd: make -j"$(nproc)" -C calc_sample test-c
           - name: ftp (verify)
@@ -127,18 +135,51 @@ jobs:
           gunzip -c devcontainer.tgz | docker load
           rm -f devcontainer.tgz
 
+      # Cache the generated-parser/serializer verification for the tls-root leg
+      # only.  Keyed on the wire spec + pinned toolchain, the two inputs that
+      # fully determine the generated TLS13.Wire.Generated.* modules and their
+      # .checked files.  On a miss the run step below recomputes and exports them
+      # (restored/saved via the tarball); actions/cache stores it post-job.  No
+      # restore-keys: a prefix-matched (stale) cache could carry .checked that no
+      # longer match the sources, so we only ever reuse an exact-input match.
+      - name: Cache generated-parser verification (tls-root)
+        id: gencache
+        if: ${{ matrix.cache_generated }}
+        uses: actions/cache@v4
+        with:
+          path: generated-checked.tar.gz
+          key: agentic-tls-generated-checked-${{ hashFiles('scripts/build-everparse.sh', 'tls.qd.rfc') }}
+
       - name: Run ${{ matrix.name }}
         env:
           CMD: ${{ matrix.cmd }}
+          CACHE_GENERATED: ${{ matrix.cache_generated }}
+          CACHE_HIT: ${{ steps.gencache.outputs.cache-hit }}
         run: |
           container=$(docker run -d agentic-tls-ci sleep infinity)
           # Inject the freshly checked-out source into the toolchain-only image
           # so the committed code is what gets tested.  tools/everparse and the
           # fetched RFCs are gitignored (absent from the checkout), so the cached
-          # toolchain and deps are left intact.
-          tar c --exclude=./.git . \
+          # toolchain and deps are left intact.  The generated-verification cache
+          # tarball is injected separately (below), so exclude it here.
+          tar c --exclude=./.git --exclude=./generated-checked.tar.gz . \
             | docker exec -i -w /workspaces/agentic-tls "$container" tar --overwrite -x
+          # tls-root only: restore the cached generated-module verification so
+          # `make` skips re-verifying the TLS13.Wire.Generated.* parsers.  A miss
+          # (no tarball) is a no-op and the modules are verified from scratch.
+          if [ -n "$CACHE_GENERATED" ]; then
+            if [ -f generated-checked.tar.gz ]; then
+              docker cp generated-checked.tar.gz "$container":/workspaces/agentic-tls/
+            fi
+            docker exec -w /workspaces/agentic-tls "$container" make restore-generated-cache
+          fi
           docker exec -w /workspaces/agentic-tls "$container" bash -lc "$CMD"
+          # On a miss, export the freshly-computed verification to the host so the
+          # post-job actions/cache save stores it under the content-hash key.
+          if [ -n "$CACHE_GENERATED" ] && [ "$CACHE_HIT" != "true" ]; then
+            docker exec -w /workspaces/agentic-tls "$container" make save-generated-cache
+            docker cp "$container":/workspaces/agentic-tls/generated-checked.tar.gz .
+          fi
           docker rm -f "$container"
 
   # ── 3. Overall gate ───────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+    - agentic
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,124 @@
-name: Minimal Workflow
+name: CI
+
 on:
+  push:
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  # ── 1. Build the dev container ────────────────────────────────────────────
+  # Builds the devcontainer image from .devcontainer/Dockerfile, then runs the
+  # onCreateCommand equivalent (./setup.sh) inside it to build the heavy
+  # EverParse/F*/KaRaMeL toolchain (tools/everparse, gitignored) and fetch the
+  # project dependencies.  The prepared container — repo + toolchain baked in at
+  # /workspaces/agentic-tls — is committed to a self-contained image and uploaded
+  # as a build artifact so the parallel test jobs below can just download + load
+  # it and run, without rebuilding the ~1h toolchain five times.
+  devcontainer:
+    name: Build devcontainer
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          df -h /
+
+      - name: Build the base devcontainer image
+        run: docker build -t agentic-tls-base -f .devcontainer/Dockerfile .
+
+      - name: Build the EverParse toolchain inside the container
+        run: |
+          # Prepare a container, copy the checked-out repo in (as the vscode
+          # user the image runs as), and build the toolchain + fetch deps there.
+          docker run -d --name prep agentic-tls-base sleep infinity
+          docker exec -u root prep mkdir -p /workspaces/agentic-tls
+          docker cp . prep:/workspaces/agentic-tls
+          docker exec -u root prep chown -R vscode:vscode /workspaces
+          docker exec -u vscode -w /workspaces/agentic-tls prep \
+            bash -lc './setup.sh --jobs "$(nproc)"'
+
+      - name: Commit the prepared container to a self-contained image
+        run: |
+          docker commit -c 'WORKDIR /workspaces/agentic-tls' prep agentic-tls-ci
+          docker rm -f prep
+
+      - name: Save the dev container image as a build artifact
+        run: docker save agentic-tls-ci | gzip > devcontainer.tar.gz
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: devcontainer-image
+          path: devcontainer.tar.gz
+          retention-days: 1
+
+  # ── 2. Parallel test jobs ─────────────────────────────────────────────────
+  # Each matrix leg downloads the prebuilt dev container image and runs one test
+  # target inside it.  fail-fast: false so every target reports independently;
+  # the ci-success gate below still requires all of them to pass.
+  tests:
+    name: ${{ matrix.name }}
+    needs: devcontainer
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: tls-root (make test)
+            cmd: make -j"$(nproc)" test
+          - name: calc (test-c)
+            cmd: make -j"$(nproc)" -C calc_sample test-c
+          - name: ftp (verify)
+            cmd: make -j"$(nproc)" -C ftp_sample
+          - name: ymodem (vloop-test + interop)
+            cmd: make -j"$(nproc)" -C ymodem_sample vloop-test && make -j"$(nproc)" -C ymodem_sample/interop
+          - name: tftp (vloop-test + interop)
+            cmd: make -j"$(nproc)" -C tftp_sample vloop-test && make -j"$(nproc)" -C tftp_sample/interop
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          df -h /
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: devcontainer-image
+
+      - name: Load the dev container image
+        run: gunzip -c devcontainer.tar.gz | docker load
+
+      - name: Run ${{ matrix.name }}
+        run: >-
+          docker run --rm agentic-tls-ci
+          bash -lc 'cd /workspaces/agentic-tls && ${{ matrix.cmd }}'
+
+  # ── 3. Overall gate ───────────────────────────────────────────────────────
+  # Succeeds only if the build and every parallel test job succeeded, giving a
+  # single status check to require on the branch/PR.
+  ci-success:
+    name: CI success
+    if: always()
+    needs: [devcontainer, tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Run a one-line script
-        run: echo "Hello, world!"
+      - name: Verify all jobs succeeded
+        run: |
+          echo "devcontainer: ${{ needs.devcontainer.result }}"
+          echo "tests:        ${{ needs.tests.result }}"
+          if [ "${{ needs.devcontainer.result }}" != "success" ] \
+             || [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "One or more CI jobs failed."
+            exit 1
+          fi
+          echo "All CI jobs passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       matrix:
         include:
           - name: tls-root (make test)
-            cmd: make -j"$(nproc)" test
+            cmd: make -j"$(nproc)" _cache/TLS13.Impl.Driver.PairingNoTailStagedBoundaryDerivation.fst.checked && make -j"$(nproc)" test
           - name: calc (test-c)
             cmd: make -j"$(nproc)" -C calc_sample test-c
           - name: ftp (verify)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,62 +9,87 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  # ── 1. Build the dev container ────────────────────────────────────────────
-  # Builds the devcontainer image from .devcontainer/Dockerfile, then runs the
-  # onCreateCommand equivalent (./setup.sh) inside it to build the heavy
-  # EverParse/F*/KaRaMeL toolchain (tools/everparse, gitignored) and fetch the
-  # project dependencies.  The prepared container — repo + toolchain baked in at
-  # /workspaces/agentic-tls — is committed to a self-contained image and uploaded
-  # as a build artifact so the parallel test jobs below can just download + load
-  # it and run, without rebuilding the ~1h toolchain five times.
+  # ── 1. Build (or reuse) the dev container ─────────────────────────────────
+  # Builds the .devcontainer image and runs ./setup.sh inside it to build the
+  # heavy EverParse/F*/KaRaMeL toolchain (tools/everparse, gitignored) and fetch
+  # the project dependencies, then commits the prepared container to a
+  # self-contained image and stores it in the GitHub Actions cache (not as a
+  # build artifact).  The cache is keyed on the files that determine the image
+  # contents — the Dockerfile (base OS + apt packages, incl. lrzsz/tftp and the
+  # in.tftpd setcap) and the toolchain build scripts (setup.sh + the pinned
+  # EverParse commit in scripts/build-everparse.sh) — so the ~1h build only
+  # re-runs when one of those changes; ordinary source edits reuse the cache.
+  # A lookup-only restore checks whether the image already exists; the build and
+  # cache-save steps run only on a miss.
   devcontainer:
-    name: Build devcontainer
+    name: Build devcontainer (cached)
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
+      - name: Look up cached dev container image
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: devcontainer.tgz
+          key: agentic-tls-devcontainer-${{ hashFiles('.devcontainer/Dockerfile', 'setup.sh', 'scripts/build-everparse.sh') }}
+          lookup-only: true
+
       - name: Free disk space
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
             /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
           df -h /
 
-      - name: Build the base devcontainer image
-        run: docker build -t agentic-tls-base -f .devcontainer/Dockerfile .
-
-      - name: Build the EverParse toolchain inside the container
+      - name: Build the dev container image + toolchain
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          # Prepare a container, copy the checked-out repo in (as the vscode
-          # user the image runs as), and build the toolchain + fetch deps there.
+          docker build -t agentic-tls-base -f .devcontainer/Dockerfile .
+          # Prepare a container, copy the checked-out repo in (as the vscode user
+          # the image runs as), and build the toolchain + fetch deps there — the
+          # devcontainer.json onCreateCommand, run by hand.
           docker run -d --name prep agentic-tls-base sleep infinity
           docker exec -u root prep mkdir -p /workspaces/agentic-tls
           docker cp . prep:/workspaces/agentic-tls
           docker exec -u root prep chown -R vscode:vscode /workspaces
           docker exec -u vscode -w /workspaces/agentic-tls prep \
             bash -lc './setup.sh --jobs "$(nproc)"'
-
-      - name: Commit the prepared container to a self-contained image
-        run: |
+          # Keep only the built toolchain (tools/everparse) and fetched deps
+          # (third_party); the project source is injected fresh by each test job,
+          # so the cached image is a pure toolchain image that never carries
+          # stale source across the many commits that reuse it.
+          docker exec -u root prep bash -c \
+            'cd /workspaces/agentic-tls && find . -mindepth 1 -maxdepth 1 \
+               ! -name tools ! -name third_party -exec rm -rf {} +'
+          docker exec -u root prep rm -rf /workspaces/agentic-tls/tools/everparse/.git
           docker commit -c 'WORKDIR /workspaces/agentic-tls' prep agentic-tls-ci
           docker rm -f prep
+          docker save agentic-tls-ci | gzip > devcontainer.tgz
 
-      - name: Save the dev container image as a build artifact
-        run: docker save agentic-tls-ci | gzip > devcontainer.tar.gz
-
-      - uses: actions/upload-artifact@v4
+      - name: Save dev container image to cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
         with:
-          name: devcontainer-image
-          path: devcontainer.tar.gz
-          retention-days: 1
+          path: devcontainer.tgz
+          key: agentic-tls-devcontainer-${{ hashFiles('.devcontainer/Dockerfile', 'setup.sh', 'scripts/build-everparse.sh') }}
 
   # ── 2. Parallel test jobs ─────────────────────────────────────────────────
-  # Each matrix leg downloads the prebuilt dev container image and runs one test
-  # target inside it.  fail-fast: false so every target reports independently;
-  # the ci-success gate below still requires all of them to pass.
+  # Each matrix leg restores the cached toolchain image and injects the FRESH
+  # checked-out source into it (the cached image is toolchain-only — see above —
+  # so the committed code is exactly what gets tested).  The freshly checked-out
+  # tree does not contain the gitignored tools/everparse or third_party/rfc, so
+  # injecting it leaves the cached toolchain and fetched RFCs untouched.
+  # fail-fast: false so every target reports independently; the ci-success gate
+  # still needs all of them.
   tests:
     name: ${{ matrix.name }}
     needs: devcontainer
@@ -85,23 +110,41 @@ jobs:
           - name: tftp (vloop-test + interop)
             cmd: make -j"$(nproc)" -C tftp_sample vloop-test && make -j"$(nproc)" -C tftp_sample/interop
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
             /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
           df -h /
 
-      - uses: actions/download-artifact@v4
+      - name: Restore cached dev container image
+        uses: actions/cache/restore@v4
         with:
-          name: devcontainer-image
+          path: devcontainer.tgz
+          key: agentic-tls-devcontainer-${{ hashFiles('.devcontainer/Dockerfile', 'setup.sh', 'scripts/build-everparse.sh') }}
+          fail-on-cache-miss: true
 
       - name: Load the dev container image
-        run: gunzip -c devcontainer.tar.gz | docker load
+        run: |
+          gunzip -c devcontainer.tgz | docker load
+          rm -f devcontainer.tgz
 
       - name: Run ${{ matrix.name }}
-        run: >-
-          docker run --rm agentic-tls-ci
-          bash -lc 'cd /workspaces/agentic-tls && ${{ matrix.cmd }}'
+        env:
+          CMD: ${{ matrix.cmd }}
+        run: |
+          container=$(docker run -d agentic-tls-ci sleep infinity)
+          # Inject the freshly checked-out source into the toolchain-only image
+          # so the committed code is what gets tested.  tools/everparse and the
+          # fetched RFCs are gitignored (absent from the checkout), so the cached
+          # toolchain and deps are left intact.
+          tar c --exclude=./.git . \
+            | docker exec -i -w /workspaces/agentic-tls "$container" tar --overwrite -x
+          docker exec -w /workspaces/agentic-tls "$container" bash -lc "$CMD"
+          docker rm -f "$container"
 
   # ── 3. Overall gate ───────────────────────────────────────────────────────
   # Succeeds only if the build and every parallel test job succeeded, giving a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: Minimal Workflow
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run a one-line script
+        run: echo "Hello, world!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
   workflow_dispatch:
 
@@ -42,13 +41,6 @@ jobs:
           path: devcontainer.tgz
           key: agentic-tls-devcontainer-${{ hashFiles('.devcontainer/Dockerfile', 'setup.sh', 'scripts/build-everparse.sh') }}
           lookup-only: true
-
-      - name: Free disk space
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
-            /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
-          df -h /
 
       - name: Build the dev container image + toolchain
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ third_party/rfc/
 _cache/
 _output/
 _extract/
+generated-checked.tar.gz
 *.checked
 *.krml
 *.smt2

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 EVERPARSE_HOME ?= $(CURDIR)/tools/everparse
 FSTAR_HOME ?= $(EVERPARSE_HOME)/opt/FStar
 FSTAR_EXE  ?= $(FSTAR_HOME)/bin/fstar.exe
-KRML_HOME  ?= $(FSTAR_HOME)/karamel
+KRML_HOME  ?= $(EVERPARSE_HOME)/opt/karamel
 # Use the installed KaRaMeL binary (opt/FStar/karamel/out/bin/krml): unlike the
 # in-tree `krml` symlink to _build/default/src/Karamel.exe, it self-locates its
 # krmllib/share, so no extra symlinks are needed.

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,52 @@ parsers:
 	$(MAKE) regen-generated
 	$(MAKE) extract-generated
 
+# ── Portable generated-verification cache (for CI) ─────────────────
+# The generated TLS13.Wire.Generated.* .checked files are a pure function of two
+# inputs: the QuackyDucky-generated sources (themselves derived from $(QD_RFC))
+# and the F*/LowParse/QuackyDucky toolchain (pinned by scripts/build-everparse.sh).
+# So a CI cache keyed on the hash of just those two files can carry the whole
+# generated-module verification result across runs.  These targets export/import
+# that result as a single relocatable tarball — exactly the artifacts the
+# $(GENERATED_STAMP) recipe produces (the sub-make cache/, the .checked copies the
+# main build consumes as already-cached, the harness .depend, and the stamp).
+GENERATED_CACHE_TARBALL ?= generated-checked.tar.gz
+
+# Bundle the verification artifacts into $(GENERATED_CACHE_TARBALL).  Only files
+# that exist are added, so a partial tree never aborts the tar.
+.PHONY: save-generated-cache
+save-generated-cache:
+	@test -f $(GENERATED_STAMP) || { \
+	  echo "No verified generated modules to save; run 'make generated-checked' first." >&2; \
+	  exit 1; }
+	@files='$(GENERATED_STAMP)'; \
+	 for f in $(GENERATED_DIR)/.depend $(GENERATED_DIR)/cache \
+	          $(GENERATED_DIR)/TLS13.Wire.Generated.*.checked; do \
+	   [ -e "$$f" ] && files="$$files $$f"; \
+	 done; \
+	 tar czf $(GENERATED_CACHE_TARBALL) $$files; \
+	 echo "Saved generated verification cache -> $(GENERATED_CACHE_TARBALL)"
+
+# Unpack a previously saved tarball, then mark the restored .checked files and
+# stamp newer than the (freshly checked-out) generated sources so Make treats
+# $(GENERATED_STAMP) as up-to-date and skips re-running the verification.  A
+# missing tarball is not an error — the build simply verifies from scratch.  F*
+# still validates every .checked against its source hash when the main build
+# consumes it, so a stale cache is safely re-verified rather than trusted.
+.PHONY: restore-generated-cache
+restore-generated-cache:
+	@if [ ! -f $(GENERATED_CACHE_TARBALL) ]; then \
+	  echo "No cache tarball at $(GENERATED_CACHE_TARBALL); nothing to restore (will verify from scratch)."; \
+	  exit 0; \
+	fi; \
+	if tar xzf $(GENERATED_CACHE_TARBALL); then \
+	  find $(GENERATED_DIR) \( -name '*.checked' -o -name '.checked.stamp' \) -exec touch {} + ; \
+	  echo "Restored generated verification cache from $(GENERATED_CACHE_TARBALL) (stamp marked fresh)."; \
+	else \
+	  echo "WARNING: could not extract $(GENERATED_CACHE_TARBALL); verifying from scratch." >&2; \
+	  rm -f $(GENERATED_STAMP); \
+	fi
+
 # ── Dependency Analysis ────────────────────────────────────────────
 # The generated .checked files must exist before `.depend` is computed, because
 # the dependency scan runs F* with --already_cached +TLS13.Wire.Generated.  The
@@ -198,7 +244,8 @@ parsers:
 # sub-make — racing under -jN.  These goals manage the generated .checked files
 # explicitly via the stamp and never need the spec/impl dependency graph.
 DEPEND_EXCLUDED_GOALS := clean regen-generated verify-generated extract-generated \
-  parsers generated-checked $(GENERATED_STAMP)
+  parsers generated-checked save-generated-cache restore-generated-cache \
+  $(GENERATED_STAMP)
 ifeq (,$(filter $(DEPEND_EXCLUDED_GOALS),$(MAKECMDGOALS)))
 include .depend
 endif
@@ -211,7 +258,7 @@ $(CACHE_DIR) $(OUTPUT_DIR) $(EXTRACT_DIR):
 	mkdir -p $@
 
 # ── Main Targets ───────────────────────────────────────────────────
-.PHONY: all verify test clean check-toolchain check-deps admit-count check-admits generated-checked parsers extract-generated
+.PHONY: all verify test clean check-toolchain check-deps admit-count check-admits generated-checked parsers extract-generated save-generated-cache restore-generated-cache
 
 all: verify
 

--- a/calc_sample/Makefile
+++ b/calc_sample/Makefile
@@ -9,7 +9,7 @@
 EVERPARSE_HOME ?= $(abspath ../tools/everparse)
 FSTAR_HOME ?= $(EVERPARSE_HOME)/opt/FStar
 FSTAR_EXE ?= $(FSTAR_HOME)/bin/fstar.exe
-KRML_HOME ?= $(FSTAR_HOME)/karamel
+KRML_HOME ?= $(EVERPARSE_HOME)/opt/karamel
 KRML ?= $(KRML_HOME)/out/bin/krml
 Z3_DIR ?= $(EVERPARSE_HOME)/opt/z3
 FSTAR_LIB ?= $(shell $(FSTAR_EXE) --locate_lib)

--- a/ftp_sample/Makefile
+++ b/ftp_sample/Makefile
@@ -1,0 +1,101 @@
+# ═══════════════════════════════════════════════════════════════════
+# FTP block-mode (MODE B) sample: Makefile (verify only)
+# ═══════════════════════════════════════════════════════════════════
+# Verifies the FTP block-mode (RFC 959 §3.4.2) data-block specification: the
+# QuackyDucky-generated wire format (a 2-byte length-prefixed data block) and
+# the hand-written Common.WireFormat / Common.WireFormatStateMachine + protocol
+# instances built on top of it.
+#
+# This sample is SPEC-ONLY: it has no executable (impl/) layer, no C extraction
+# and no interop harness — only the F* specification is verified.  The other
+# samples (calc/tftp/ymodem) additionally extract verified driver loops to C.
+#
+#   make verify   Verify all FTPBlock.* modules (default).
+#   make gen      Regenerate FTPBlock.Wire.Generated.* from ftp_block.qd.rfc.
+#   make clean    Remove build artifacts.
+
+# ── Toolchain ──────────────────────────────────────────────────────
+EVERPARSE_HOME ?= $(abspath ../tools/everparse)
+FSTAR_HOME ?= $(EVERPARSE_HOME)/opt/FStar
+FSTAR_EXE ?= $(FSTAR_HOME)/bin/fstar.exe
+QD ?= $(EVERPARSE_HOME)/bin/qd.exe
+Z3_DIR ?= $(EVERPARSE_HOME)/opt/z3
+LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
+export PATH := $(Z3_DIR):$(PATH)
+
+# ── Directories ────────────────────────────────────────────────────
+CACHE_DIR   = _cache
+SPEC_DIR    = spec
+OUTPUT_DIR  = _output
+
+# ── F* Flags ───────────────────────────────────────────────────────
+INCLUDES = \
+  --include ../common \
+  --include $(LOWPARSE_HOME) \
+  --include $(LOWPARSE_HOME)/pulse \
+  --include $(SPEC_DIR)
+
+FSTAR_FLAGS = \
+  --cache_checked_modules \
+  --cache_dir $(CACHE_DIR) \
+  --odir $(OUTPUT_DIR) \
+  --already_cached 'Prims,FStar,Pulse,PulseCore,C,Spec.Loops,LowParse' \
+  --warn_error -321-241-272-288 \
+  --report_assumes warn \
+  --ext optimize_let_vc \
+  --ext fly_deps \
+  $(INCLUDES)
+
+FSTAR = $(FSTAR_EXE) $(FSTAR_FLAGS)
+
+# ── Source Files ───────────────────────────────────────────────────
+COMMON_FILES = $(wildcard ../common/*.fst ../common/*.fsti)
+SPEC_FILES = $(wildcard $(SPEC_DIR)/*.fst $(SPEC_DIR)/*.fsti)
+ALL_FILES  = $(COMMON_FILES) $(SPEC_FILES)
+
+.PHONY: all verify gen clean check-admits help
+
+all: verify
+
+# ── Dependency Analysis ────────────────────────────────────────────
+.depend: $(ALL_FILES)
+	@echo "Generating dependencies..."
+	@$(FSTAR) --dep full $(ALL_FILES) --output_deps_to $@
+
+-include .depend
+
+# ── Generic Verification Rules ────────────────────────────────────
+$(CACHE_DIR)/%.checked: | $(CACHE_DIR)
+	@echo "Verifying $<"
+	@$(FSTAR) $<
+	@touch $@
+
+$(CACHE_DIR):
+	@mkdir -p $@
+
+verify: $(ALL_CHECKED_FILES)
+	@echo "All FTPBlock modules verified"
+
+check-admits:
+	@echo "Checking for admits ..."
+	@grep -rn "admit *()" $(SPEC_DIR) 2>/dev/null || echo "  none"
+
+# ── Regenerate the wire format from the QuackyDucky description ─────
+# (Run after editing ftp_block.qd.rfc; then `make verify` to refresh .checked.)
+gen:
+	@echo "Regenerating FTPBlock.Wire.Generated.* from ftp_block.qd.rfc ..."
+	$(QD) -pulse -prefix "FTPBlock.Wire.Generated." -odir $(SPEC_DIR) ftp_block.qd.rfc
+	@echo "Regenerated — now run 'make verify'."
+
+# ── Clean ──────────────────────────────────────────────────────────
+clean:
+	rm -rf $(CACHE_DIR) $(OUTPUT_DIR)
+	rm -f .depend
+	@echo "Cleaned build artifacts"
+
+help:
+	@echo "FTP block-mode sample - Makefile targets:"
+	@echo "  make verify        - Verify all FTPBlock.* modules (default)"
+	@echo "  make gen           - Regenerate FTPBlock.Wire.Generated.* from ftp_block.qd.rfc"
+	@echo "  make check-admits  - List admits in spec/"
+	@echo "  make clean         - Remove build artifacts"

--- a/ftp_sample/spec/FTPBlock.Wire.Generated.Ftp_block.fst
+++ b/ftp_sample/spec/FTPBlock.Wire.Generated.Ftp_block.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 (* Type of field data*)
 open FTPBlock.Wire.Generated.Ftp_block_data
 
@@ -91,7 +89,7 @@ let read_ftp_block : PPB.copyful_parse ftp_block_vmatch ftp_block_parser ftp_blo
   assert_norm (ftp_block_parser_kind == ftp_block'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair LPPI.jump_u8 (PPB.copyful_parse_leaf (PPB.leaf_reader_of_serialized (LPPI.read_u8' ()))) () read_ftp_block_data) synth_ftp_block synth_ftp_block_recip
 
-let free_ftp_block : PPB.free_t ftp_block_vmatch = (PPC.free_pair (PPB.free_leaf #U8.t) free_ftp_block_data)
+let free_ftp_block : PPB.free_t ftp_block_vmatch = fun x #v -> ((PPC.free_pair (PPB.free_leaf #U8.t) free_ftp_block_data)) x #v
 
 let write_ftp_block : PPB.l2r_safe_writer ftp_block_vmatch ftp_block_serializer ftp_block_conv =
   synth_ftp_block_injective ();
@@ -100,7 +98,7 @@ let write_ftp_block : PPB.l2r_safe_writer ftp_block_vmatch ftp_block_serializer 
 
 let size_ftp_block : PPB.l2r_safe_size ftp_block_vmatch ftp_block_serializer ftp_block_conv =
   synth_ftp_block_injective ();
-  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair fits_u64_squash (PPB.l2r_safe_size_leaf LPI.serialize_u8 1sz) () size_ftp_block_data) synth_ftp_block synth_ftp_block_recip
+  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair (PPB.l2r_safe_size_leaf LPI.serialize_u8 1sz) () size_ftp_block_data) synth_ftp_block synth_ftp_block_recip
 
 let ftp_block_bytesize_eqn x =
   [@inline_let] let _ = synth_ftp_block_injective () in

--- a/ftp_sample/spec/FTPBlock.Wire.Generated.Ftp_block_data.fst
+++ b/ftp_sample/spec/FTPBlock.Wire.Generated.Ftp_block_data.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let ftp_block_data_parser = LP.parse_bounded_seq_vlbytes 0 65535
 
 noextract let ftp_block_data_serializer = LP.serialize_bounded_seq_vlbytes 0 65535
 
 let ftp_block_data_bytesize_eq x = ()
 
-let ftp_block_data_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let ftp_block_data_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
-let ftp_block_data_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let ftp_block_data_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_ftp_block_data = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_ftp_block_data = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_ftp_block_data : PPB.free_t ftp_block_data_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_ftp_block_data = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let write_ftp_block_data = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
-let size_ftp_block_data = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let size_ftp_block_data = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
 let ftp_block_data_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 65535 x
 

--- a/generated/TLS13.Wire.Generated.Alert.fst
+++ b/generated/TLS13.Wire.Generated.Alert.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let synth_alert_recip_inverse () : Lemma (LP.synth_inverse synth_alert_recip synth_alert) = ()
 
 let synth_alert_injective () : Lemma (LP.synth_injective synth_alert) =
@@ -90,7 +88,7 @@ let alert_writer =
   [@inline_let] let _ = synth_alert_inverse () in
   LPC.l2r_leaf_write_synth alert'_writer synth_alert synth_alert_recip (fun x -> synth_alert_recip x)
 
-inline_for_extraction let alert'_leaf_size : LPS.leaf_size alert'_serializer = (LPC.leaf_size_pair alertLevel_leaf_size () alertDescription_leaf_size fits_u64_squash (_ by (FStar.Tactics.norm [delta; iota; zeta; primops]; FStar.Tactics.smt ())))
+inline_for_extraction let alert'_leaf_size : LPS.leaf_size alert'_serializer = (LPC.leaf_size_pair alertLevel_leaf_size () alertDescription_leaf_size (_ by (FStar.Tactics.norm [delta; iota; zeta; primops]; FStar.Tactics.smt ())))
 
 let alert_leaf_size =
   [@inline_let] let _ = synth_alert_injective () in
@@ -102,7 +100,7 @@ let read_alert : PPB.copyful_parse alert_vmatch alert_parser alert_conv =
   assert_norm (alert_parser_kind == alert'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair alertLevel_jumper read_alertLevel () read_alertDescription) synth_alert synth_alert_recip
 
-let free_alert : PPB.free_t alert_vmatch = (PPC.free_pair free_alertLevel free_alertDescription)
+let free_alert : PPB.free_t alert_vmatch = fun x #v -> ((PPC.free_pair free_alertLevel free_alertDescription)) x #v
 
 let write_alert : PPB.l2r_safe_writer alert_vmatch alert_serializer alert_conv =
   synth_alert_injective ();
@@ -111,7 +109,7 @@ let write_alert : PPB.l2r_safe_writer alert_vmatch alert_serializer alert_conv =
 
 let size_alert : PPB.l2r_safe_size alert_vmatch alert_serializer alert_conv =
   synth_alert_injective ();
-  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair fits_u64_squash size_alertLevel () size_alertDescription) synth_alert synth_alert_recip
+  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair size_alertLevel () size_alertDescription) synth_alert synth_alert_recip
 
 let alert_bytesize_eqn x =
   [@inline_let] let _ = synth_alert_injective () in

--- a/generated/TLS13.Wire.Generated.Alert.fsti
+++ b/generated/TLS13.Wire.Generated.Alert.fsti
@@ -36,20 +36,20 @@ module LPITE = LowParse.PulseParse.IfThenElse
 open TLS13.Wire.Generated.AlertLevel
 open TLS13.Wire.Generated.AlertDescription
 
-noextract type alert = {
+type alert = {
   level : alertLevel;
   description : alertDescription;
 }
 
-noextract type alert' = (alertLevel & alertDescription)
+type alert' = (alertLevel & alertDescription)
 
-inline_for_extraction noextract let synth_alert (x: alert') : alert =
+inline_for_extraction let synth_alert (x: alert') : alert =
   match x with (level,description) -> {
     level = level;
     description = description;
   }
 
-inline_for_extraction noextract let synth_alert_recip (x: alert) : alert' = (x.level,x.description)
+inline_for_extraction let synth_alert_recip (x: alert) : alert' = (x.level,x.description)
 
 inline_for_extraction noextract let alert_parser_kind = LP.strong_parser_kind 2 2 None
 

--- a/generated/TLS13.Wire.Generated.AlertDescription.fst
+++ b/generated/TLS13.Wire.Generated.AlertDescription.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let alertDescription_repr_parser = LPI.parse_u8
 
 noextract let alertDescription_repr_serializer = LPI.serialize_u8
@@ -49,9 +47,9 @@ inline_for_extraction noextract let alertDescription_repr_reader = (PPB.leaf_rea
 
 inline_for_extraction noextract let alertDescription_repr_writer = (LPPI.l2r_leaf_write_u8 ())
 
-inline_for_extraction let synth_alertDescription (x: LP.enum_key alertDescription_enum) : Tot alertDescription = x
+inline_for_extraction noextract let synth_alertDescription (x: LP.enum_key alertDescription_enum) : Tot alertDescription = x
 
-inline_for_extraction let synth_alertDescription_inv (x: alertDescription) : Tot (LP.enum_key alertDescription_enum) =
+inline_for_extraction noextract let synth_alertDescription_inv (x: alertDescription) : Tot (LP.enum_key alertDescription_enum) =
   [@inline_let] let _ : squash (LP.list_mem x (LP.list_map fst alertDescription_enum)) =
     _ by (LP.synth_maybe_enum_key_inv_unknown_tac x)
   in

--- a/generated/TLS13.Wire.Generated.AlertLevel.fst
+++ b/generated/TLS13.Wire.Generated.AlertLevel.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let alertLevel_repr_parser = LPI.parse_u8
 
 noextract let alertLevel_repr_serializer = LPI.serialize_u8
@@ -49,9 +47,9 @@ inline_for_extraction noextract let alertLevel_repr_reader = (PPB.leaf_reader_of
 
 inline_for_extraction noextract let alertLevel_repr_writer = (LPPI.l2r_leaf_write_u8 ())
 
-inline_for_extraction let synth_alertLevel (x: LP.enum_key alertLevel_enum) : Tot alertLevel = x
+inline_for_extraction noextract let synth_alertLevel (x: LP.enum_key alertLevel_enum) : Tot alertLevel = x
 
-inline_for_extraction let synth_alertLevel_inv (x: alertLevel) : Tot (LP.enum_key alertLevel_enum) =
+inline_for_extraction noextract let synth_alertLevel_inv (x: alertLevel) : Tot (LP.enum_key alertLevel_enum) =
   [@inline_let] let _ : squash (LP.list_mem x (LP.list_map fst alertLevel_enum)) =
     _ by (LP.synth_maybe_enum_key_inv_unknown_tac x)
   in

--- a/generated/TLS13.Wire.Generated.Certificate.fst
+++ b/generated/TLS13.Wire.Generated.Certificate.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 (* Type of field certificate_request_context*)
 open TLS13.Wire.Generated.Certificate_certificate_request_context
 
@@ -94,7 +92,7 @@ let read_certificate : PPB.copyful_parse certificate_vmatch certificate_parser c
   assert_norm (certificate_parser_kind == certificate'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair certificate_certificate_request_context_jumper read_certificate_certificate_request_context () read_certificate_certificate_list) synth_certificate synth_certificate_recip
 
-let free_certificate : PPB.free_t certificate_vmatch = (PPC.free_pair free_certificate_certificate_request_context free_certificate_certificate_list)
+let free_certificate : PPB.free_t certificate_vmatch = fun x #v -> ((PPC.free_pair free_certificate_certificate_request_context free_certificate_certificate_list)) x #v
 
 let write_certificate : PPB.l2r_safe_writer certificate_vmatch certificate_serializer certificate_conv =
   synth_certificate_injective ();

--- a/generated/TLS13.Wire.Generated.CertificateEntry.fst
+++ b/generated/TLS13.Wire.Generated.CertificateEntry.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 (* Type of field cert_data*)
 open TLS13.Wire.Generated.CertificateEntry_cert_data
 
@@ -94,7 +92,7 @@ let read_certificateEntry : PPB.copyful_parse certificateEntry_vmatch certificat
   assert_norm (certificateEntry_parser_kind == certificateEntry'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair certificateEntry_cert_data_jumper read_certificateEntry_cert_data () read_certificateEntry_extensions) synth_certificateEntry synth_certificateEntry_recip
 
-let free_certificateEntry : PPB.free_t certificateEntry_vmatch = (PPC.free_pair free_certificateEntry_cert_data free_certificateEntry_extensions)
+let free_certificateEntry : PPB.free_t certificateEntry_vmatch = fun x #v -> ((PPC.free_pair free_certificateEntry_cert_data free_certificateEntry_extensions)) x #v
 
 let write_certificateEntry : PPB.l2r_safe_writer certificateEntry_vmatch certificateEntry_serializer certificateEntry_conv =
   synth_certificateEntry_injective ();

--- a/generated/TLS13.Wire.Generated.CertificateEntry_cert_data.fst
+++ b/generated/TLS13.Wire.Generated.CertificateEntry_cert_data.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let certificateEntry_cert_data_parser = LP.parse_bounded_seq_vlbytes 1 16777215
 
 noextract let certificateEntry_cert_data_serializer = LP.serialize_bounded_seq_vlbytes 1 16777215
 
 let certificateEntry_cert_data_bytesize_eq x = ()
 
-let certificateEntry_cert_data_validator = LSeqB.validate_bounded_seq_vlbytes 1 16777215 (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+let certificateEntry_cert_data_validator = LSeqB.validate_bounded_seq_vlbytes 1 16777215 (PPBI.leaf_read_bounded_integer_3 ())
 
-let certificateEntry_cert_data_jumper = LSeqB.jump_bounded_seq_vlbytes 1 16777215 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 fits_u64_squash)) fits_u64_squash
+let certificateEntry_cert_data_jumper = LSeqB.jump_bounded_seq_vlbytes 1 16777215 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 ()))
 
-let read_certificateEntry_cert_data = LSeqB.copyful_parse_bounded_seq_vlbytes 1 16777215 (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+let read_certificateEntry_cert_data = LSeqB.copyful_parse_bounded_seq_vlbytes 1 16777215 (PPBI.leaf_read_bounded_integer_3 ())
 
 let free_certificateEntry_cert_data : PPB.free_t certificateEntry_cert_data_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_certificateEntry_cert_data = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 16777215 (LSeqB.mk_seq_sizet 16777215 fits_u64_squash) 3sz fits_u64_squash
+let write_certificateEntry_cert_data = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 1ul 16777215 16777215ul 3sz
 
-let size_certificateEntry_cert_data = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 16777215 (LSeqB.mk_seq_sizet 16777215 fits_u64_squash) 3sz fits_u64_squash
+let size_certificateEntry_cert_data = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 1ul 16777215 16777215ul 3sz
 
 let certificateEntry_cert_data_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 1 16777215 x
 

--- a/generated/TLS13.Wire.Generated.CertificateEntry_extensions.fst
+++ b/generated/TLS13.Wire.Generated.CertificateEntry_extensions.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let certificateEntry_extensions_list_bytesize_nil = LP.serialize_list_nil extensionCertificate_parser extensionCertificate_serializer
 
 let certificateEntry_extensions_list_bytesize_cons x y = LP.serialize_list_cons extensionCertificate_parser extensionCertificate_serializer x y; (extensionCertificate_bytesize_eq (x))
@@ -54,12 +52,12 @@ let certificateEntry_extensions_serializer = LP.serialize_synth _ synth_certific
 let certificateEntry_extensions_bytesize_eq x = ()
 
 inline_for_extraction let certificateEntry_extensions'_validator : LPS.validator certificateEntry_extensions'_parser =
-  PPVD.validate_bounded_vldata_strong 0 65535 (LP.serialize_list _ extensionCertificate_serializer) (PPLS.validate_list extensionCertificate_validator ()) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 65535 (LP.serialize_list _ extensionCertificate_serializer) (PPLS.validate_list extensionCertificate_validator ()) (PPBI.leaf_read_bounded_integer_2 ())
 
 let certificateEntry_extensions_validator = LPC.validate_synth certificateEntry_extensions'_validator synth_certificateEntry_extensions
 
 inline_for_extraction let certificateEntry_extensions'_jumper : LPS.jumper certificateEntry_extensions'_parser =
-  PPVD.jump_bounded_vldata_strong 0 65535 (LP.serialize_list _ extensionCertificate_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 65535 (LP.serialize_list _ extensionCertificate_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let certificateEntry_extensions_jumper = LPC.jump_synth certificateEntry_extensions'_jumper synth_certificateEntry_extensions
 
@@ -76,7 +74,7 @@ let read_certificateEntry_extensions : PPB.copyful_parse certificateEntry_extens
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 (LP.serialize_list _ extensionCertificate_serializer)
        (PPLS.copyful_parse_list read_extensionCertificate extensionCertificate_jumper ())
-       (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_2 ()))
     synth_certificateEntry_extensions synth_certificateEntry_extensions_recip
 
 let free_certificateEntry_extensions : PPB.free_t certificateEntry_extensions_vmatch =
@@ -88,7 +86,7 @@ let write_certificateEntry_extensions : PPB.l2r_safe_writer certificateEntry_ext
   assert_norm ((LP.get_parser_kind extensionCertificate_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind extensionCertificate_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz (LP.serialize_list _ extensionCertificate_serializer)
-       (PPLS.l2r_safe_writer_list extensionCertificate_serializer write_extensionCertificate ()) fits_u64_squash) <: PPB.l2r_safe_writer _ certificateEntry_extensions'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 65535 65535ul 2 2sz (LP.serialize_list _ extensionCertificate_serializer)
+       (PPLS.l2r_safe_writer_list extensionCertificate_serializer write_extensionCertificate ())) <: PPB.l2r_safe_writer _ certificateEntry_extensions'_serializer _)
     synth_certificateEntry_extensions synth_certificateEntry_extensions_recip
 

--- a/generated/TLS13.Wire.Generated.CertificateVerify.fst
+++ b/generated/TLS13.Wire.Generated.CertificateVerify.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 (* Type of field signature*)
 open TLS13.Wire.Generated.CertificateVerify_signature
 
@@ -91,7 +89,7 @@ let read_certificateVerify : PPB.copyful_parse certificateVerify_vmatch certific
   assert_norm (certificateVerify_parser_kind == certificateVerify'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair signatureScheme_jumper read_signatureScheme () read_certificateVerify_signature) synth_certificateVerify synth_certificateVerify_recip
 
-let free_certificateVerify : PPB.free_t certificateVerify_vmatch = (PPC.free_pair free_signatureScheme free_certificateVerify_signature)
+let free_certificateVerify : PPB.free_t certificateVerify_vmatch = fun x #v -> ((PPC.free_pair free_signatureScheme free_certificateVerify_signature)) x #v
 
 let write_certificateVerify : PPB.l2r_safe_writer certificateVerify_vmatch certificateVerify_serializer certificateVerify_conv =
   synth_certificateVerify_injective ();
@@ -100,7 +98,7 @@ let write_certificateVerify : PPB.l2r_safe_writer certificateVerify_vmatch certi
 
 let size_certificateVerify : PPB.l2r_safe_size certificateVerify_vmatch certificateVerify_serializer certificateVerify_conv =
   synth_certificateVerify_injective ();
-  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair fits_u64_squash size_signatureScheme () size_certificateVerify_signature) synth_certificateVerify synth_certificateVerify_recip
+  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair size_signatureScheme () size_certificateVerify_signature) synth_certificateVerify synth_certificateVerify_recip
 
 let certificateVerify_bytesize_eqn x =
   [@inline_let] let _ = synth_certificateVerify_injective () in

--- a/generated/TLS13.Wire.Generated.CertificateVerify_signature.fst
+++ b/generated/TLS13.Wire.Generated.CertificateVerify_signature.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let certificateVerify_signature_parser = LP.parse_bounded_seq_vlbytes 0 65535
 
 noextract let certificateVerify_signature_serializer = LP.serialize_bounded_seq_vlbytes 0 65535
 
 let certificateVerify_signature_bytesize_eq x = ()
 
-let certificateVerify_signature_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let certificateVerify_signature_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
-let certificateVerify_signature_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let certificateVerify_signature_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_certificateVerify_signature = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_certificateVerify_signature = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_certificateVerify_signature : PPB.free_t certificateVerify_signature_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_certificateVerify_signature = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let write_certificateVerify_signature = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
-let size_certificateVerify_signature = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let size_certificateVerify_signature = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
 let certificateVerify_signature_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 65535 x
 

--- a/generated/TLS13.Wire.Generated.Certificate_certificate_list.fst
+++ b/generated/TLS13.Wire.Generated.Certificate_certificate_list.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let certificate_certificate_list_list_bytesize_nil = LP.serialize_list_nil certificateEntry_parser certificateEntry_serializer
 
 let certificate_certificate_list_list_bytesize_cons x y = LP.serialize_list_cons certificateEntry_parser certificateEntry_serializer x y; (certificateEntry_bytesize_eq (x))
@@ -54,12 +52,12 @@ let certificate_certificate_list_serializer = LP.serialize_synth _ synth_certifi
 let certificate_certificate_list_bytesize_eq x = ()
 
 inline_for_extraction let certificate_certificate_list'_validator : LPS.validator certificate_certificate_list'_parser =
-  PPVD.validate_bounded_vldata_strong 0 16777215 (LP.serialize_list _ certificateEntry_serializer) (PPLS.validate_list certificateEntry_validator ()) (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 16777215 (LP.serialize_list _ certificateEntry_serializer) (PPLS.validate_list certificateEntry_validator ()) (PPBI.leaf_read_bounded_integer_3 ())
 
 let certificate_certificate_list_validator = LPC.validate_synth certificate_certificate_list'_validator synth_certificate_certificate_list
 
 inline_for_extraction let certificate_certificate_list'_jumper : LPS.jumper certificate_certificate_list'_parser =
-  PPVD.jump_bounded_vldata_strong 0 16777215 (LP.serialize_list _ certificateEntry_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 16777215 (LP.serialize_list _ certificateEntry_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 ()))
 
 let certificate_certificate_list_jumper = LPC.jump_synth certificate_certificate_list'_jumper synth_certificate_certificate_list
 
@@ -76,7 +74,7 @@ let read_certificate_certificate_list : PPB.copyful_parse certificate_certificat
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 0 16777215 (LP.serialize_list _ certificateEntry_serializer)
        (PPLS.copyful_parse_list read_certificateEntry certificateEntry_jumper ())
-       (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_3 ()))
     synth_certificate_certificate_list synth_certificate_certificate_list_recip
 
 let free_certificate_certificate_list : PPB.free_t certificate_certificate_list_vmatch =
@@ -88,7 +86,7 @@ let write_certificate_certificate_list : PPB.l2r_safe_writer certificate_certifi
   assert_norm ((LP.get_parser_kind certificateEntry_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind certificateEntry_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 16777215 (LSeqB.mk_seq_sizet 16777215 fits_u64_squash) 3 3sz (LP.serialize_list _ certificateEntry_serializer)
-       (PPLS.l2r_safe_writer_list certificateEntry_serializer write_certificateEntry ()) fits_u64_squash) <: PPB.l2r_safe_writer _ certificate_certificate_list'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 16777215 16777215ul 3 3sz (LP.serialize_list _ certificateEntry_serializer)
+       (PPLS.l2r_safe_writer_list certificateEntry_serializer write_certificateEntry ())) <: PPB.l2r_safe_writer _ certificate_certificate_list'_serializer _)
     synth_certificate_certificate_list synth_certificate_certificate_list_recip
 

--- a/generated/TLS13.Wire.Generated.Certificate_certificate_request_context.fst
+++ b/generated/TLS13.Wire.Generated.Certificate_certificate_request_context.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let certificate_certificate_request_context_parser = LP.parse_bounded_seq_vlbytes 0 255
 
 noextract let certificate_certificate_request_context_serializer = LP.serialize_bounded_seq_vlbytes 0 255
 
 let certificate_certificate_request_context_bytesize_eq x = ()
 
-let certificate_certificate_request_context_validator = LSeqB.validate_bounded_seq_vlbytes 0 255 (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+let certificate_certificate_request_context_validator = LSeqB.validate_bounded_seq_vlbytes 0 255 (PPBI.leaf_read_bounded_integer_1 ())
 
-let certificate_certificate_request_context_jumper = LSeqB.jump_bounded_seq_vlbytes 0 255 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 255)) (PPBI.leaf_read_bounded_integer_1 fits_u64_squash)) fits_u64_squash
+let certificate_certificate_request_context_jumper = LSeqB.jump_bounded_seq_vlbytes 0 255 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 255)) (PPBI.leaf_read_bounded_integer_1 ()))
 
-let read_certificate_certificate_request_context = LSeqB.copyful_parse_bounded_seq_vlbytes 0 255 (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+let read_certificate_certificate_request_context = LSeqB.copyful_parse_bounded_seq_vlbytes 0 255 (PPBI.leaf_read_bounded_integer_1 ())
 
 let free_certificate_certificate_request_context : PPB.free_t certificate_certificate_request_context_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_certificate_certificate_request_context = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 255 (LSeqB.mk_seq_sizet 255 fits_u64_squash) 1sz fits_u64_squash
+let write_certificate_certificate_request_context = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 255 255ul 1sz
 
-let size_certificate_certificate_request_context = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 255 (LSeqB.mk_seq_sizet 255 fits_u64_squash) 1sz fits_u64_squash
+let size_certificate_certificate_request_context = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 255 255ul 1sz
 
 let certificate_certificate_request_context_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 255 x
 

--- a/generated/TLS13.Wire.Generated.ChangeCipherSpec.fst
+++ b/generated/TLS13.Wire.Generated.ChangeCipherSpec.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let changeCipherSpec_parser = LPI.parse_u8
 
 noextract let changeCipherSpec_serializer = LPI.serialize_u8
 
 let changeCipherSpec_bytesize_eq x = ()
 
-let changeCipherSpec_reader = (PPB.leaf_reader_of_serialized (LPPI.read_u8' ()))
+let changeCipherSpec_reader = fun input #pm #v -> ((PPB.leaf_reader_of_serialized (LPPI.read_u8' ()))) input #pm #v
 
-let changeCipherSpec_writer = (LPPI.l2r_leaf_write_u8 ())
+let changeCipherSpec_writer = fun x out offset #v -> ((LPPI.l2r_leaf_write_u8 ())) x out offset #v
 
-let changeCipherSpec_leaf_size = (LPS.leaf_size_constant_size LPI.serialize_u8 1sz (_ by (FStar.Tactics.norm [delta; iota; zeta; primops]; FStar.Tactics.smt ())))
+let changeCipherSpec_leaf_size = fun x -> ((LPS.leaf_size_constant_size LPI.serialize_u8 1sz (_ by (FStar.Tactics.norm [delta; iota; zeta; primops]; FStar.Tactics.smt ())))) x
 
-let read_changeCipherSpec : PPB.copyful_parse changeCipherSpec_vmatch changeCipherSpec_parser changeCipherSpec_conv = (PPB.copyful_parse_leaf (PPB.leaf_reader_of_serialized (LPPI.read_u8' ())))
+let read_changeCipherSpec : PPB.copyful_parse changeCipherSpec_vmatch changeCipherSpec_parser changeCipherSpec_conv = fun input #pm #v -> ((PPB.copyful_parse_leaf (PPB.leaf_reader_of_serialized (LPPI.read_u8' ())))) input #pm #v
 
-let free_changeCipherSpec : PPB.free_t changeCipherSpec_vmatch = (PPB.free_leaf #U8.t)
+let free_changeCipherSpec : PPB.free_t changeCipherSpec_vmatch = fun x #v -> ((PPB.free_leaf #U8.t)) x #v
 
-let write_changeCipherSpec : PPB.l2r_safe_writer changeCipherSpec_vmatch changeCipherSpec_serializer changeCipherSpec_conv = (PPB.l2r_safe_writer_leaf LPI.serialize_u8 1sz (LPPI.l2r_leaf_write_u8 ()))
+let write_changeCipherSpec : PPB.l2r_safe_writer changeCipherSpec_vmatch changeCipherSpec_serializer changeCipherSpec_conv = fun x #y out #v perr -> ((PPB.l2r_safe_writer_leaf LPI.serialize_u8 1sz (LPPI.l2r_leaf_write_u8 ()))) x #y out #v perr
 
 let changeCipherSpec_bytesize_eqn x = (assert (FStar.Seq.length (LP.serialize LP.serialize_u8 (x)) == 1))
 

--- a/generated/TLS13.Wire.Generated.CipherSuite.fst
+++ b/generated/TLS13.Wire.Generated.CipherSuite.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let cipherSuite_repr_parser = LPI.parse_u16
 
 noextract let cipherSuite_repr_serializer = LPI.serialize_u16
@@ -49,7 +47,7 @@ inline_for_extraction noextract let cipherSuite_repr_reader = (PPB.leaf_reader_o
 
 inline_for_extraction noextract let cipherSuite_repr_writer = (LPPI.l2r_leaf_write_u16 ())
 
-inline_for_extraction let synth_cipherSuite (x:LP.maybe_enum_key cipherSuite_enum) : cipherSuite =
+inline_for_extraction noextract let synth_cipherSuite (x:LP.maybe_enum_key cipherSuite_enum) : cipherSuite = 
   match x with
   | LP.Known k -> k
   | LP.Unknown y ->
@@ -57,7 +55,7 @@ inline_for_extraction let synth_cipherSuite (x:LP.maybe_enum_key cipherSuite_enu
     [@inline_let] let _ = assert_norm (LP.list_mem v (LP.list_map snd cipherSuite_enum) == known_cipherSuite_repr v) in
     Unknown_cipherSuite v
 
-inline_for_extraction let synth_cipherSuite_inv (x:cipherSuite) : LP.maybe_enum_key cipherSuite_enum =
+inline_for_extraction noextract let synth_cipherSuite_inv (x:cipherSuite) : LP.maybe_enum_key cipherSuite_enum = 
   match x with
   | Unknown_cipherSuite y ->
     [@inline_let] let v : U16.t = y in
@@ -77,7 +75,7 @@ let lemma_synth_cipherSuite_inv' () : Lemma
     (_ by (LP.forall_maybe_enum_key_unknown_tac ()))
 
 let lemma_synth_cipherSuite_inj () : Lemma
-  (LP.synth_injective synth_cipherSuite) =
+  (LP.synth_injective synth_cipherSuite) = 
   lemma_synth_cipherSuite_inv' ();
   LP.synth_inverse_synth_injective synth_cipherSuite synth_cipherSuite_inv
 
@@ -86,7 +84,6 @@ let lemma_synth_cipherSuite_inv () : Lemma
   (LP.synth_inverse synth_cipherSuite synth_cipherSuite_inv) = allow_inversion cipherSuite; ()
 
 #pop-options
-
 noextract let parse_maybe_cipherSuite_key : LP.parser _ (LP.maybe_enum_key cipherSuite_enum) =
   LP.parse_maybe_enum_key cipherSuite_repr_parser cipherSuite_enum
 
@@ -133,3 +130,4 @@ let free_cipherSuite = PPB.free_leaf
 let write_cipherSuite = PPB.l2r_safe_writer_leaf cipherSuite_serializer 2sz cipherSuite_writer
 
 let size_cipherSuite = PPB.l2r_safe_size_leaf cipherSuite_serializer 2sz
+

--- a/generated/TLS13.Wire.Generated.CipherSuite.fsti
+++ b/generated/TLS13.Wire.Generated.CipherSuite.fsti
@@ -92,3 +92,4 @@ val free_cipherSuite : PPB.free_t cipherSuite_vmatch
 val write_cipherSuite : PPB.l2r_safe_writer cipherSuite_vmatch cipherSuite_serializer cipherSuite_conv
 
 val size_cipherSuite : PPB.l2r_safe_size cipherSuite_vmatch cipherSuite_serializer cipherSuite_conv
+

--- a/generated/TLS13.Wire.Generated.ClientHello.fst
+++ b/generated/TLS13.Wire.Generated.ClientHello.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 (* Type of field legacy_session_id*)
 open TLS13.Wire.Generated.ClientHello_legacy_session_id
 
@@ -103,7 +101,7 @@ let read_clientHello : PPB.copyful_parse clientHello_vmatch clientHello_parser c
   assert_norm (clientHello_parser_kind == clientHello'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair (LPC.jump_nondep_then (LPC.jump_nondep_then protocolVersion_jumper random_jumper) (LPC.jump_nondep_then clientHello_legacy_session_id_jumper clientHello_cipher_suites_jumper)) (PPC.copyful_parse_pair (LPC.jump_nondep_then protocolVersion_jumper random_jumper) (PPC.copyful_parse_pair protocolVersion_jumper read_protocolVersion () read_random) () (PPC.copyful_parse_pair clientHello_legacy_session_id_jumper read_clientHello_legacy_session_id () read_clientHello_cipher_suites)) () (PPC.copyful_parse_pair clientHello_legacy_compression_methods_jumper read_clientHello_legacy_compression_methods () read_clientHello_extensions)) synth_clientHello synth_clientHello_recip
 
-let free_clientHello : PPB.free_t clientHello_vmatch = (PPC.free_pair (PPC.free_pair (PPC.free_pair free_protocolVersion free_random) (PPC.free_pair free_clientHello_legacy_session_id free_clientHello_cipher_suites)) (PPC.free_pair free_clientHello_legacy_compression_methods free_clientHello_extensions))
+let free_clientHello : PPB.free_t clientHello_vmatch = fun x #v -> ((PPC.free_pair (PPC.free_pair (PPC.free_pair free_protocolVersion free_random) (PPC.free_pair free_clientHello_legacy_session_id free_clientHello_cipher_suites)) (PPC.free_pair free_clientHello_legacy_compression_methods free_clientHello_extensions))) x #v
 
 let write_clientHello : PPB.l2r_safe_writer clientHello_vmatch clientHello_serializer clientHello_conv =
   synth_clientHello_injective ();

--- a/generated/TLS13.Wire.Generated.ClientHello_cipher_suites.fst
+++ b/generated/TLS13.Wire.Generated.ClientHello_cipher_suites.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 private let pre : squash (LP.vldata_vlarray_precond 2 65534 cipherSuite_parser 1 32767 == true) = _ by (FStar.Tactics.trefl ())
 
 let clientHello_cipher_suites_parser =
@@ -48,10 +46,10 @@ let clientHello_cipher_suites_serializer =
 let clientHello_cipher_suites_bytesize_eq x = ()
 
 let clientHello_cipher_suites_validator =
- PPAR.validate_vlarray 2 65534 cipherSuite_serializer cipherSuite_validator 1 32767 () (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+ PPAR.validate_vlarray 2 65534 cipherSuite_serializer cipherSuite_validator 1 32767 () (PPBI.leaf_read_bounded_integer_2 ()) ()
 
 let clientHello_cipher_suites_jumper =
- PPAR.jump_vlarray 2 65534 cipherSuite_serializer 1 32767 () (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65534)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+ PPAR.jump_vlarray 2 65534 cipherSuite_serializer 1 32767 () (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65534)) (PPBI.leaf_read_bounded_integer_2 ())) ()
 
 let clientHello_cipher_suites_bytesize_eqn x = LP.length_serialize_vlarray 2 65534 cipherSuite_serializer 1 32767 () x
 
@@ -63,7 +61,7 @@ let read_clientHello_cipher_suites : PPB.copyful_parse clientHello_cipher_suites
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 2 65534 (LP.serialize_list _ cipherSuite_serializer)
        (PPLS.copyful_parse_list read_cipherSuite cipherSuite_jumper ())
-       (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_2 ()))
     (LP.vldata_to_vlarray 2 65534 cipherSuite_serializer 1 32767 ())
     (LP.vlarray_to_vldata 2 65534 cipherSuite_serializer 1 32767 ())
 
@@ -76,8 +74,8 @@ let write_clientHello_cipher_suites : PPB.l2r_safe_writer clientHello_cipher_sui
   assert_norm ((LP.get_parser_kind cipherSuite_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind cipherSuite_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 2 (LSeqB.mk_seq_sizet 2 fits_u64_squash) 65534 (LSeqB.mk_seq_sizet 65534 fits_u64_squash) 2 2sz (LP.serialize_list _ cipherSuite_serializer)
-       (PPLS.l2r_safe_writer_list cipherSuite_serializer write_cipherSuite ()) fits_u64_squash) <: PPB.l2r_safe_writer _ (LP.serialize_bounded_vldata_strong 2 65534 (LP.serialize_list _ cipherSuite_serializer)) _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 2 2ul 65534 65534ul 2 2sz (LP.serialize_list _ cipherSuite_serializer)
+       (PPLS.l2r_safe_writer_list cipherSuite_serializer write_cipherSuite ())) <: PPB.l2r_safe_writer _ (LP.serialize_bounded_vldata_strong 2 65534 (LP.serialize_list _ cipherSuite_serializer)) _)
     (LP.vldata_to_vlarray 2 65534 cipherSuite_serializer 1 32767 ())
     (LP.vlarray_to_vldata 2 65534 cipherSuite_serializer 1 32767 ())
 

--- a/generated/TLS13.Wire.Generated.ClientHello_extensions.fst
+++ b/generated/TLS13.Wire.Generated.ClientHello_extensions.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let clientHello_extensions_list_bytesize_nil = LP.serialize_list_nil extensionClientHello_parser extensionClientHello_serializer
 
 let clientHello_extensions_list_bytesize_cons x y = LP.serialize_list_cons extensionClientHello_parser extensionClientHello_serializer x y; (extensionClientHello_bytesize_eq (x))
@@ -54,12 +52,12 @@ let clientHello_extensions_serializer = LP.serialize_synth _ synth_clientHello_e
 let clientHello_extensions_bytesize_eq x = ()
 
 inline_for_extraction let clientHello_extensions'_validator : LPS.validator clientHello_extensions'_parser =
-  PPVD.validate_bounded_vldata_strong 8 65535 (LP.serialize_list _ extensionClientHello_serializer) (PPLS.validate_list extensionClientHello_validator ()) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 8 65535 (LP.serialize_list _ extensionClientHello_serializer) (PPLS.validate_list extensionClientHello_validator ()) (PPBI.leaf_read_bounded_integer_2 ())
 
 let clientHello_extensions_validator = LPC.validate_synth clientHello_extensions'_validator synth_clientHello_extensions
 
 inline_for_extraction let clientHello_extensions'_jumper : LPS.jumper clientHello_extensions'_parser =
-  PPVD.jump_bounded_vldata_strong 8 65535 (LP.serialize_list _ extensionClientHello_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 8 65535 (LP.serialize_list _ extensionClientHello_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let clientHello_extensions_jumper = LPC.jump_synth clientHello_extensions'_jumper synth_clientHello_extensions
 
@@ -76,7 +74,7 @@ let read_clientHello_extensions : PPB.copyful_parse clientHello_extensions_vmatc
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 8 65535 (LP.serialize_list _ extensionClientHello_serializer)
        (PPLS.copyful_parse_list read_extensionClientHello extensionClientHello_jumper ())
-       (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_2 ()))
     synth_clientHello_extensions synth_clientHello_extensions_recip
 
 let free_clientHello_extensions : PPB.free_t clientHello_extensions_vmatch =
@@ -88,7 +86,7 @@ let write_clientHello_extensions : PPB.l2r_safe_writer clientHello_extensions_vm
   assert_norm ((LP.get_parser_kind extensionClientHello_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind extensionClientHello_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 8 (LSeqB.mk_seq_sizet 8 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz (LP.serialize_list _ extensionClientHello_serializer)
-       (PPLS.l2r_safe_writer_list extensionClientHello_serializer write_extensionClientHello ()) fits_u64_squash) <: PPB.l2r_safe_writer _ clientHello_extensions'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 8 8ul 65535 65535ul 2 2sz (LP.serialize_list _ extensionClientHello_serializer)
+       (PPLS.l2r_safe_writer_list extensionClientHello_serializer write_extensionClientHello ())) <: PPB.l2r_safe_writer _ clientHello_extensions'_serializer _)
     synth_clientHello_extensions synth_clientHello_extensions_recip
 

--- a/generated/TLS13.Wire.Generated.ClientHello_legacy_compression_methods.fst
+++ b/generated/TLS13.Wire.Generated.ClientHello_legacy_compression_methods.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let clientHello_legacy_compression_methods_parser = LP.parse_bounded_seq_vlbytes 1 255
 
 noextract let clientHello_legacy_compression_methods_serializer = LP.serialize_bounded_seq_vlbytes 1 255
 
 let clientHello_legacy_compression_methods_bytesize_eq x = ()
 
-let clientHello_legacy_compression_methods_validator = LSeqB.validate_bounded_seq_vlbytes 1 255 (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+let clientHello_legacy_compression_methods_validator = LSeqB.validate_bounded_seq_vlbytes 1 255 (PPBI.leaf_read_bounded_integer_1 ())
 
-let clientHello_legacy_compression_methods_jumper = LSeqB.jump_bounded_seq_vlbytes 1 255 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 255)) (PPBI.leaf_read_bounded_integer_1 fits_u64_squash)) fits_u64_squash
+let clientHello_legacy_compression_methods_jumper = LSeqB.jump_bounded_seq_vlbytes 1 255 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 255)) (PPBI.leaf_read_bounded_integer_1 ()))
 
-let read_clientHello_legacy_compression_methods = LSeqB.copyful_parse_bounded_seq_vlbytes 1 255 (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+let read_clientHello_legacy_compression_methods = LSeqB.copyful_parse_bounded_seq_vlbytes 1 255 (PPBI.leaf_read_bounded_integer_1 ())
 
 let free_clientHello_legacy_compression_methods : PPB.free_t clientHello_legacy_compression_methods_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_clientHello_legacy_compression_methods = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 255 (LSeqB.mk_seq_sizet 255 fits_u64_squash) 1sz fits_u64_squash
+let write_clientHello_legacy_compression_methods = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 1ul 255 255ul 1sz
 
-let size_clientHello_legacy_compression_methods = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 255 (LSeqB.mk_seq_sizet 255 fits_u64_squash) 1sz fits_u64_squash
+let size_clientHello_legacy_compression_methods = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 1ul 255 255ul 1sz
 
 let clientHello_legacy_compression_methods_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 1 255 x
 

--- a/generated/TLS13.Wire.Generated.ClientHello_legacy_session_id.fst
+++ b/generated/TLS13.Wire.Generated.ClientHello_legacy_session_id.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let clientHello_legacy_session_id_parser = LP.parse_bounded_seq_vlbytes 0 32
 
 noextract let clientHello_legacy_session_id_serializer = LP.serialize_bounded_seq_vlbytes 0 32
 
 let clientHello_legacy_session_id_bytesize_eq x = ()
 
-let clientHello_legacy_session_id_validator = LSeqB.validate_bounded_seq_vlbytes 0 32 (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+let clientHello_legacy_session_id_validator = LSeqB.validate_bounded_seq_vlbytes 0 32 (PPBI.leaf_read_bounded_integer_1 ())
 
-let clientHello_legacy_session_id_jumper = LSeqB.jump_bounded_seq_vlbytes 0 32 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 32)) (PPBI.leaf_read_bounded_integer_1 fits_u64_squash)) fits_u64_squash
+let clientHello_legacy_session_id_jumper = LSeqB.jump_bounded_seq_vlbytes 0 32 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 32)) (PPBI.leaf_read_bounded_integer_1 ()))
 
-let read_clientHello_legacy_session_id = LSeqB.copyful_parse_bounded_seq_vlbytes 0 32 (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+let read_clientHello_legacy_session_id = LSeqB.copyful_parse_bounded_seq_vlbytes 0 32 (PPBI.leaf_read_bounded_integer_1 ())
 
 let free_clientHello_legacy_session_id : PPB.free_t clientHello_legacy_session_id_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_clientHello_legacy_session_id = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 32 (LSeqB.mk_seq_sizet 32 fits_u64_squash) 1sz fits_u64_squash
+let write_clientHello_legacy_session_id = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 32 32ul 1sz
 
-let size_clientHello_legacy_session_id = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 32 (LSeqB.mk_seq_sizet 32 fits_u64_squash) 1sz fits_u64_squash
+let size_clientHello_legacy_session_id = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 32 32ul 1sz
 
 let clientHello_legacy_session_id_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 32 x
 

--- a/generated/TLS13.Wire.Generated.ContentType.fst
+++ b/generated/TLS13.Wire.Generated.ContentType.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let contentType_repr_parser = LPI.parse_u8
 
 noextract let contentType_repr_serializer = LPI.serialize_u8
@@ -49,9 +47,9 @@ inline_for_extraction noextract let contentType_repr_reader = (PPB.leaf_reader_o
 
 inline_for_extraction noextract let contentType_repr_writer = (LPPI.l2r_leaf_write_u8 ())
 
-inline_for_extraction let synth_contentType (x: LP.enum_key contentType_enum) : Tot contentType = x
+inline_for_extraction noextract let synth_contentType (x: LP.enum_key contentType_enum) : Tot contentType = x
 
-inline_for_extraction let synth_contentType_inv (x: contentType) : Tot (LP.enum_key contentType_enum) =
+inline_for_extraction noextract let synth_contentType_inv (x: contentType) : Tot (LP.enum_key contentType_enum) =
   [@inline_let] let _ : squash (LP.list_mem x (LP.list_map fst contentType_enum)) =
     _ by (LP.synth_maybe_enum_key_inv_unknown_tac x)
   in

--- a/generated/TLS13.Wire.Generated.EncryptedExtensions.fst
+++ b/generated/TLS13.Wire.Generated.EncryptedExtensions.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let encryptedExtensions_list_bytesize_nil = LP.serialize_list_nil extensionEncryptedExtensions_parser extensionEncryptedExtensions_serializer
 
 let encryptedExtensions_list_bytesize_cons x y = LP.serialize_list_cons extensionEncryptedExtensions_parser extensionEncryptedExtensions_serializer x y; (extensionEncryptedExtensions_bytesize_eq (x))
@@ -54,12 +52,12 @@ let encryptedExtensions_serializer = LP.serialize_synth _ synth_encryptedExtensi
 let encryptedExtensions_bytesize_eq x = ()
 
 inline_for_extraction let encryptedExtensions'_validator : LPS.validator encryptedExtensions'_parser =
-  PPVD.validate_bounded_vldata_strong 0 65535 (LP.serialize_list _ extensionEncryptedExtensions_serializer) (PPLS.validate_list extensionEncryptedExtensions_validator ()) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 65535 (LP.serialize_list _ extensionEncryptedExtensions_serializer) (PPLS.validate_list extensionEncryptedExtensions_validator ()) (PPBI.leaf_read_bounded_integer_2 ())
 
 let encryptedExtensions_validator = LPC.validate_synth encryptedExtensions'_validator synth_encryptedExtensions
 
 inline_for_extraction let encryptedExtensions'_jumper : LPS.jumper encryptedExtensions'_parser =
-  PPVD.jump_bounded_vldata_strong 0 65535 (LP.serialize_list _ extensionEncryptedExtensions_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 65535 (LP.serialize_list _ extensionEncryptedExtensions_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let encryptedExtensions_jumper = LPC.jump_synth encryptedExtensions'_jumper synth_encryptedExtensions
 
@@ -76,7 +74,7 @@ let read_encryptedExtensions : PPB.copyful_parse encryptedExtensions_vmatch encr
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 (LP.serialize_list _ extensionEncryptedExtensions_serializer)
        (PPLS.copyful_parse_list read_extensionEncryptedExtensions extensionEncryptedExtensions_jumper ())
-       (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_2 ()))
     synth_encryptedExtensions synth_encryptedExtensions_recip
 
 let free_encryptedExtensions : PPB.free_t encryptedExtensions_vmatch =
@@ -88,7 +86,7 @@ let write_encryptedExtensions : PPB.l2r_safe_writer encryptedExtensions_vmatch e
   assert_norm ((LP.get_parser_kind extensionEncryptedExtensions_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind extensionEncryptedExtensions_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz (LP.serialize_list _ extensionEncryptedExtensions_serializer)
-       (PPLS.l2r_safe_writer_list extensionEncryptedExtensions_serializer write_extensionEncryptedExtensions ()) fits_u64_squash) <: PPB.l2r_safe_writer _ encryptedExtensions'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 65535 65535ul 2 2sz (LP.serialize_list _ extensionEncryptedExtensions_serializer)
+       (PPLS.l2r_safe_writer_list extensionEncryptedExtensions_serializer write_extensionEncryptedExtensions ())) <: PPB.l2r_safe_writer _ encryptedExtensions'_serializer _)
     synth_encryptedExtensions synth_encryptedExtensions_recip
 

--- a/generated/TLS13.Wire.Generated.ExtensionCertificate.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionCertificate.fst
@@ -37,8 +37,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 // Need high Z3 limits for large sum types
 #set-options "--z3rlimit 360"
 
@@ -170,7 +168,7 @@ noextract inline_for_extraction let synth_extensionCertificate_cases_recip (k:LP
       (match x with Extension_data_server_name y -> extensionCertificate_known_case k' Server_name y)
    | _ -> [@inline_let] let _ = synth_extensionCertificate_cases_recip_pre_intro (LP.Known k') in false_elim ()
 
-inline_for_extraction let extensionCertificate_sum : LP.dsum = LP.make_dsum' extensionType_enum key_of_extensionCertificate
+inline_for_extraction noextract let extensionCertificate_sum : LP.dsum = LP.make_dsum' extensionType_enum key_of_extensionCertificate
   extensionCertificate_case_of_extensionType extensionCertificate_extension_data_default synth_extensionCertificate_cases synth_extensionCertificate_cases_recip
   (_ by (LP.make_dsum_synth_case_recip_synth_case_known_tac ()))
   (_ by (LP.make_dsum_synth_case_recip_synth_case_unknown_tac ()))

--- a/generated/TLS13.Wire.Generated.ExtensionCertificate_extension_data_default.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionCertificate_extension_data_default.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionCertificate_extension_data_default_parser = LP.parse_bounded_seq_vlbytes 0 65535
 
 noextract let extensionCertificate_extension_data_default_serializer = LP.serialize_bounded_seq_vlbytes 0 65535
 
 let extensionCertificate_extension_data_default_bytesize_eq x = ()
 
-let extensionCertificate_extension_data_default_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let extensionCertificate_extension_data_default_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
-let extensionCertificate_extension_data_default_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let extensionCertificate_extension_data_default_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_extensionCertificate_extension_data_default = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_extensionCertificate_extension_data_default = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_extensionCertificate_extension_data_default : PPB.free_t extensionCertificate_extension_data_default_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_extensionCertificate_extension_data_default = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let write_extensionCertificate_extension_data_default = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
-let size_extensionCertificate_extension_data_default = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let size_extensionCertificate_extension_data_default = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
 let extensionCertificate_extension_data_default_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 65535 x
 

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello.fst
@@ -37,8 +37,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 // Need high Z3 limits for large sum types
 #set-options "--z3rlimit 360"
 
@@ -170,7 +168,7 @@ noextract inline_for_extraction let synth_extensionClientHello_cases_recip (k:LP
       (match x with Extension_data_application_layer_protocol_negotiation y -> extensionClientHello_known_case k' Application_layer_protocol_negotiation y)
    | _ -> [@inline_let] let _ = synth_extensionClientHello_cases_recip_pre_intro (LP.Known k') in false_elim ()
 
-inline_for_extraction let extensionClientHello_sum : LP.dsum = LP.make_dsum' extensionType_enum key_of_extensionClientHello
+inline_for_extraction noextract let extensionClientHello_sum : LP.dsum = LP.make_dsum' extensionType_enum key_of_extensionClientHello
   extensionClientHello_case_of_extensionType extensionClientHello_extension_data_default synth_extensionClientHello_cases synth_extensionClientHello_cases_recip
   (_ by (LP.make_dsum_synth_case_recip_synth_case_known_tac ()))
   (_ by (LP.make_dsum_synth_case_recip_synth_case_unknown_tac ()))

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_default.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_default.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionClientHello_extension_data_default_parser = LP.parse_bounded_seq_vlbytes 0 65535
 
 noextract let extensionClientHello_extension_data_default_serializer = LP.serialize_bounded_seq_vlbytes 0 65535
 
 let extensionClientHello_extension_data_default_bytesize_eq x = ()
 
-let extensionClientHello_extension_data_default_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let extensionClientHello_extension_data_default_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
-let extensionClientHello_extension_data_default_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let extensionClientHello_extension_data_default_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_extensionClientHello_extension_data_default = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_extensionClientHello_extension_data_default = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_extensionClientHello_extension_data_default : PPB.free_t extensionClientHello_extension_data_default_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_extensionClientHello_extension_data_default = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let write_extensionClientHello_extension_data_default = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
-let size_extensionClientHello_extension_data_default = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let size_extensionClientHello_extension_data_default = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
 let extensionClientHello_extension_data_default_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 65535 x
 

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_key_share.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_key_share.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionClientHello_extension_data_key_share'_parser : LP.parser _ extensionClientHello_extension_data_key_share' =
   LP.parse_bounded_vldata_strong 0 65535 keyShareClientHello_serializer
 
@@ -50,12 +48,12 @@ let extensionClientHello_extension_data_key_share_serializer = LP.serialize_synt
 let extensionClientHello_extension_data_key_share_bytesize_eq x = ()
 
 inline_for_extraction let extensionClientHello_extension_data_key_share'_validator : LPS.validator extensionClientHello_extension_data_key_share'_parser =
-  PPVD.validate_bounded_vldata_strong 0 65535 keyShareClientHello_serializer keyShareClientHello_validator (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 65535 keyShareClientHello_serializer keyShareClientHello_validator (PPBI.leaf_read_bounded_integer_2 ())
 
 let extensionClientHello_extension_data_key_share_validator = LPC.validate_synth extensionClientHello_extension_data_key_share'_validator synth_extensionClientHello_extension_data_key_share
 
 inline_for_extraction let extensionClientHello_extension_data_key_share'_jumper : LPS.jumper extensionClientHello_extension_data_key_share'_parser =
-  PPVD.jump_bounded_vldata_strong 0 65535 keyShareClientHello_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 65535 keyShareClientHello_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let extensionClientHello_extension_data_key_share_jumper = LPC.jump_synth extensionClientHello_extension_data_key_share'_jumper synth_extensionClientHello_extension_data_key_share
 
@@ -63,7 +61,7 @@ let extensionClientHello_extension_data_key_share_accessor =
   PPC.accessor_ext
     (PPC.accessor_compose
       (PPC.accessor_synth synth_extensionClientHello_extension_data_key_share synth_extensionClientHello_extension_data_key_share_recip)
-      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 keyShareClientHello_serializer (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash) ())
+      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 keyShareClientHello_serializer (PPBI.leaf_read_bounded_integer_2 ())) ())
     extensionClientHello_extension_data_key_share_clens ()
 
 
@@ -75,7 +73,7 @@ let read_extensionClientHello_extension_data_key_share : PPB.copyful_parse exten
   extensionClientHello_extension_data_key_share_copyful_synth_injective ();
   extensionClientHello_extension_data_key_share_copyful_synth_inverse ();
   PPC.copyful_parse_synth
-    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 keyShareClientHello_serializer read_keyShareClientHello (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 keyShareClientHello_serializer read_keyShareClientHello (PPBI.leaf_read_bounded_integer_2 ()))
     synth_extensionClientHello_extension_data_key_share synth_extensionClientHello_extension_data_key_share_recip
 
 let free_extensionClientHello_extension_data_key_share : PPB.free_t extensionClientHello_extension_data_key_share_vmatch =
@@ -85,7 +83,7 @@ let write_extensionClientHello_extension_data_key_share : PPB.l2r_safe_writer ex
   extensionClientHello_extension_data_key_share_copyful_synth_injective ();
   extensionClientHello_extension_data_key_share_copyful_synth_inverse ();
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz keyShareClientHello_serializer write_keyShareClientHello fits_u64_squash) <: PPB.l2r_safe_writer _ extensionClientHello_extension_data_key_share'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 65535 65535ul 2 2sz keyShareClientHello_serializer write_keyShareClientHello) <: PPB.l2r_safe_writer _ extensionClientHello_extension_data_key_share'_serializer _)
     synth_extensionClientHello_extension_data_key_share synth_extensionClientHello_extension_data_key_share_recip
 
 let extensionClientHello_extension_data_key_share_bytesize_eqn x =

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_key_share.fsti
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_key_share.fsti
@@ -35,14 +35,14 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.KeyShareClientHello
 
-type extensionClientHello_extension_data_key_share = x:keyShareClientHello{let l = (keyShareClientHello_bytesize (x)) in 0 <= l /\ l <= 65535}
+noextract type extensionClientHello_extension_data_key_share = x:keyShareClientHello{let l = (keyShareClientHello_bytesize (x)) in 0 <= l /\ l <= 65535}
 
-type extensionClientHello_extension_data_key_share' = LP.parse_bounded_vldata_strong_t 0 65535 keyShareClientHello_serializer
+noextract type extensionClientHello_extension_data_key_share' = LP.parse_bounded_vldata_strong_t 0 65535 keyShareClientHello_serializer
 
-inline_for_extraction let synth_extensionClientHello_extension_data_key_share (x: extensionClientHello_extension_data_key_share') : Tot extensionClientHello_extension_data_key_share =
+inline_for_extraction noextract let synth_extensionClientHello_extension_data_key_share (x: extensionClientHello_extension_data_key_share') : Tot extensionClientHello_extension_data_key_share =
   [@inline_let] let _ = (keyShareClientHello_bytesize_eq (x)) in x
 
-inline_for_extraction let synth_extensionClientHello_extension_data_key_share_recip (x: extensionClientHello_extension_data_key_share) : Tot extensionClientHello_extension_data_key_share' =
+inline_for_extraction noextract let synth_extensionClientHello_extension_data_key_share_recip (x: extensionClientHello_extension_data_key_share) : Tot extensionClientHello_extension_data_key_share' =
   [@inline_let] let _ = (keyShareClientHello_bytesize_eq (x)) in x
 
 inline_for_extraction noextract let extensionClientHello_extension_data_key_share_parser_kind = LP.strong_parser_kind 4 65537 None

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_server_name.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_server_name.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionClientHello_extension_data_server_name'_parser : LP.parser _ extensionClientHello_extension_data_server_name' =
   LP.parse_bounded_vldata_strong 0 65535 serverNameList_serializer
 
@@ -50,12 +48,12 @@ let extensionClientHello_extension_data_server_name_serializer = LP.serialize_sy
 let extensionClientHello_extension_data_server_name_bytesize_eq x = ()
 
 inline_for_extraction let extensionClientHello_extension_data_server_name'_validator : LPS.validator extensionClientHello_extension_data_server_name'_parser =
-  PPVD.validate_bounded_vldata_strong 0 65535 serverNameList_serializer serverNameList_validator (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 65535 serverNameList_serializer serverNameList_validator (PPBI.leaf_read_bounded_integer_2 ())
 
 let extensionClientHello_extension_data_server_name_validator = LPC.validate_synth extensionClientHello_extension_data_server_name'_validator synth_extensionClientHello_extension_data_server_name
 
 inline_for_extraction let extensionClientHello_extension_data_server_name'_jumper : LPS.jumper extensionClientHello_extension_data_server_name'_parser =
-  PPVD.jump_bounded_vldata_strong 0 65535 serverNameList_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 65535 serverNameList_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let extensionClientHello_extension_data_server_name_jumper = LPC.jump_synth extensionClientHello_extension_data_server_name'_jumper synth_extensionClientHello_extension_data_server_name
 
@@ -63,7 +61,7 @@ let extensionClientHello_extension_data_server_name_accessor =
   PPC.accessor_ext
     (PPC.accessor_compose
       (PPC.accessor_synth synth_extensionClientHello_extension_data_server_name synth_extensionClientHello_extension_data_server_name_recip)
-      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 serverNameList_serializer (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash) ())
+      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 serverNameList_serializer (PPBI.leaf_read_bounded_integer_2 ())) ())
     extensionClientHello_extension_data_server_name_clens ()
 
 
@@ -75,7 +73,7 @@ let read_extensionClientHello_extension_data_server_name : PPB.copyful_parse ext
   extensionClientHello_extension_data_server_name_copyful_synth_injective ();
   extensionClientHello_extension_data_server_name_copyful_synth_inverse ();
   PPC.copyful_parse_synth
-    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 serverNameList_serializer read_serverNameList (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 serverNameList_serializer read_serverNameList (PPBI.leaf_read_bounded_integer_2 ()))
     synth_extensionClientHello_extension_data_server_name synth_extensionClientHello_extension_data_server_name_recip
 
 let free_extensionClientHello_extension_data_server_name : PPB.free_t extensionClientHello_extension_data_server_name_vmatch =
@@ -85,7 +83,7 @@ let write_extensionClientHello_extension_data_server_name : PPB.l2r_safe_writer 
   extensionClientHello_extension_data_server_name_copyful_synth_injective ();
   extensionClientHello_extension_data_server_name_copyful_synth_inverse ();
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz serverNameList_serializer write_serverNameList fits_u64_squash) <: PPB.l2r_safe_writer _ extensionClientHello_extension_data_server_name'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 65535 65535ul 2 2sz serverNameList_serializer write_serverNameList) <: PPB.l2r_safe_writer _ extensionClientHello_extension_data_server_name'_serializer _)
     synth_extensionClientHello_extension_data_server_name synth_extensionClientHello_extension_data_server_name_recip
 
 let extensionClientHello_extension_data_server_name_bytesize_eqn x =

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_server_name.fsti
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_server_name.fsti
@@ -35,14 +35,14 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.ServerNameList
 
-type extensionClientHello_extension_data_server_name = x:serverNameList{let l = (serverNameList_bytesize (x)) in 0 <= l /\ l <= 65535}
+noextract type extensionClientHello_extension_data_server_name = x:serverNameList{let l = (serverNameList_bytesize (x)) in 0 <= l /\ l <= 65535}
 
-type extensionClientHello_extension_data_server_name' = LP.parse_bounded_vldata_strong_t 0 65535 serverNameList_serializer
+noextract type extensionClientHello_extension_data_server_name' = LP.parse_bounded_vldata_strong_t 0 65535 serverNameList_serializer
 
-inline_for_extraction let synth_extensionClientHello_extension_data_server_name (x: extensionClientHello_extension_data_server_name') : Tot extensionClientHello_extension_data_server_name =
+inline_for_extraction noextract let synth_extensionClientHello_extension_data_server_name (x: extensionClientHello_extension_data_server_name') : Tot extensionClientHello_extension_data_server_name =
   [@inline_let] let _ = (serverNameList_bytesize_eq (x)) in x
 
-inline_for_extraction let synth_extensionClientHello_extension_data_server_name_recip (x: extensionClientHello_extension_data_server_name) : Tot extensionClientHello_extension_data_server_name' =
+inline_for_extraction noextract let synth_extensionClientHello_extension_data_server_name_recip (x: extensionClientHello_extension_data_server_name) : Tot extensionClientHello_extension_data_server_name' =
   [@inline_let] let _ = (serverNameList_bytesize_eq (x)) in x
 
 inline_for_extraction noextract let extensionClientHello_extension_data_server_name_parser_kind = LP.strong_parser_kind 5 65537 None

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_signature_algorithms.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_signature_algorithms.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionClientHello_extension_data_signature_algorithms'_parser : LP.parser _ extensionClientHello_extension_data_signature_algorithms' =
   LP.parse_bounded_vldata_strong 0 65535 signatureSchemeList_serializer
 
@@ -50,12 +48,12 @@ let extensionClientHello_extension_data_signature_algorithms_serializer = LP.ser
 let extensionClientHello_extension_data_signature_algorithms_bytesize_eq x = ()
 
 inline_for_extraction let extensionClientHello_extension_data_signature_algorithms'_validator : LPS.validator extensionClientHello_extension_data_signature_algorithms'_parser =
-  PPVD.validate_bounded_vldata_strong 0 65535 signatureSchemeList_serializer signatureSchemeList_validator (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 65535 signatureSchemeList_serializer signatureSchemeList_validator (PPBI.leaf_read_bounded_integer_2 ())
 
 let extensionClientHello_extension_data_signature_algorithms_validator = LPC.validate_synth extensionClientHello_extension_data_signature_algorithms'_validator synth_extensionClientHello_extension_data_signature_algorithms
 
 inline_for_extraction let extensionClientHello_extension_data_signature_algorithms'_jumper : LPS.jumper extensionClientHello_extension_data_signature_algorithms'_parser =
-  PPVD.jump_bounded_vldata_strong 0 65535 signatureSchemeList_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 65535 signatureSchemeList_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let extensionClientHello_extension_data_signature_algorithms_jumper = LPC.jump_synth extensionClientHello_extension_data_signature_algorithms'_jumper synth_extensionClientHello_extension_data_signature_algorithms
 
@@ -63,7 +61,7 @@ let extensionClientHello_extension_data_signature_algorithms_accessor =
   PPC.accessor_ext
     (PPC.accessor_compose
       (PPC.accessor_synth synth_extensionClientHello_extension_data_signature_algorithms synth_extensionClientHello_extension_data_signature_algorithms_recip)
-      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 signatureSchemeList_serializer (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash) ())
+      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 signatureSchemeList_serializer (PPBI.leaf_read_bounded_integer_2 ())) ())
     extensionClientHello_extension_data_signature_algorithms_clens ()
 
 
@@ -75,7 +73,7 @@ let read_extensionClientHello_extension_data_signature_algorithms : PPB.copyful_
   extensionClientHello_extension_data_signature_algorithms_copyful_synth_injective ();
   extensionClientHello_extension_data_signature_algorithms_copyful_synth_inverse ();
   PPC.copyful_parse_synth
-    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 signatureSchemeList_serializer read_signatureSchemeList (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 signatureSchemeList_serializer read_signatureSchemeList (PPBI.leaf_read_bounded_integer_2 ()))
     synth_extensionClientHello_extension_data_signature_algorithms synth_extensionClientHello_extension_data_signature_algorithms_recip
 
 let free_extensionClientHello_extension_data_signature_algorithms : PPB.free_t extensionClientHello_extension_data_signature_algorithms_vmatch =
@@ -85,7 +83,7 @@ let write_extensionClientHello_extension_data_signature_algorithms : PPB.l2r_saf
   extensionClientHello_extension_data_signature_algorithms_copyful_synth_injective ();
   extensionClientHello_extension_data_signature_algorithms_copyful_synth_inverse ();
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz signatureSchemeList_serializer write_signatureSchemeList fits_u64_squash) <: PPB.l2r_safe_writer _ extensionClientHello_extension_data_signature_algorithms'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 65535 65535ul 2 2sz signatureSchemeList_serializer write_signatureSchemeList) <: PPB.l2r_safe_writer _ extensionClientHello_extension_data_signature_algorithms'_serializer _)
     synth_extensionClientHello_extension_data_signature_algorithms synth_extensionClientHello_extension_data_signature_algorithms_recip
 
 let extensionClientHello_extension_data_signature_algorithms_bytesize_eqn x =

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_signature_algorithms.fsti
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_signature_algorithms.fsti
@@ -35,14 +35,14 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.SignatureSchemeList
 
-type extensionClientHello_extension_data_signature_algorithms = x:signatureSchemeList{let l = (signatureSchemeList_bytesize (x)) in 0 <= l /\ l <= 65535}
+noextract type extensionClientHello_extension_data_signature_algorithms = x:signatureSchemeList{let l = (signatureSchemeList_bytesize (x)) in 0 <= l /\ l <= 65535}
 
-type extensionClientHello_extension_data_signature_algorithms' = LP.parse_bounded_vldata_strong_t 0 65535 signatureSchemeList_serializer
+noextract type extensionClientHello_extension_data_signature_algorithms' = LP.parse_bounded_vldata_strong_t 0 65535 signatureSchemeList_serializer
 
-inline_for_extraction let synth_extensionClientHello_extension_data_signature_algorithms (x: extensionClientHello_extension_data_signature_algorithms') : Tot extensionClientHello_extension_data_signature_algorithms =
+inline_for_extraction noextract let synth_extensionClientHello_extension_data_signature_algorithms (x: extensionClientHello_extension_data_signature_algorithms') : Tot extensionClientHello_extension_data_signature_algorithms =
   [@inline_let] let _ = (signatureSchemeList_bytesize_eq (x)) in x
 
-inline_for_extraction let synth_extensionClientHello_extension_data_signature_algorithms_recip (x: extensionClientHello_extension_data_signature_algorithms) : Tot extensionClientHello_extension_data_signature_algorithms' =
+inline_for_extraction noextract let synth_extensionClientHello_extension_data_signature_algorithms_recip (x: extensionClientHello_extension_data_signature_algorithms) : Tot extensionClientHello_extension_data_signature_algorithms' =
   [@inline_let] let _ = (signatureSchemeList_bytesize_eq (x)) in x
 
 inline_for_extraction noextract let extensionClientHello_extension_data_signature_algorithms_parser_kind = LP.strong_parser_kind 6 65537 None

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_supported_groups.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_supported_groups.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionClientHello_extension_data_supported_groups'_parser : LP.parser _ extensionClientHello_extension_data_supported_groups' =
   LP.parse_bounded_vldata_strong 0 65535 namedGroupList_serializer
 
@@ -50,12 +48,12 @@ let extensionClientHello_extension_data_supported_groups_serializer = LP.seriali
 let extensionClientHello_extension_data_supported_groups_bytesize_eq x = ()
 
 inline_for_extraction let extensionClientHello_extension_data_supported_groups'_validator : LPS.validator extensionClientHello_extension_data_supported_groups'_parser =
-  PPVD.validate_bounded_vldata_strong 0 65535 namedGroupList_serializer namedGroupList_validator (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 65535 namedGroupList_serializer namedGroupList_validator (PPBI.leaf_read_bounded_integer_2 ())
 
 let extensionClientHello_extension_data_supported_groups_validator = LPC.validate_synth extensionClientHello_extension_data_supported_groups'_validator synth_extensionClientHello_extension_data_supported_groups
 
 inline_for_extraction let extensionClientHello_extension_data_supported_groups'_jumper : LPS.jumper extensionClientHello_extension_data_supported_groups'_parser =
-  PPVD.jump_bounded_vldata_strong 0 65535 namedGroupList_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 65535 namedGroupList_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let extensionClientHello_extension_data_supported_groups_jumper = LPC.jump_synth extensionClientHello_extension_data_supported_groups'_jumper synth_extensionClientHello_extension_data_supported_groups
 
@@ -63,7 +61,7 @@ let extensionClientHello_extension_data_supported_groups_accessor =
   PPC.accessor_ext
     (PPC.accessor_compose
       (PPC.accessor_synth synth_extensionClientHello_extension_data_supported_groups synth_extensionClientHello_extension_data_supported_groups_recip)
-      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 namedGroupList_serializer (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash) ())
+      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 namedGroupList_serializer (PPBI.leaf_read_bounded_integer_2 ())) ())
     extensionClientHello_extension_data_supported_groups_clens ()
 
 
@@ -75,7 +73,7 @@ let read_extensionClientHello_extension_data_supported_groups : PPB.copyful_pars
   extensionClientHello_extension_data_supported_groups_copyful_synth_injective ();
   extensionClientHello_extension_data_supported_groups_copyful_synth_inverse ();
   PPC.copyful_parse_synth
-    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 namedGroupList_serializer read_namedGroupList (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 namedGroupList_serializer read_namedGroupList (PPBI.leaf_read_bounded_integer_2 ()))
     synth_extensionClientHello_extension_data_supported_groups synth_extensionClientHello_extension_data_supported_groups_recip
 
 let free_extensionClientHello_extension_data_supported_groups : PPB.free_t extensionClientHello_extension_data_supported_groups_vmatch =
@@ -85,7 +83,7 @@ let write_extensionClientHello_extension_data_supported_groups : PPB.l2r_safe_wr
   extensionClientHello_extension_data_supported_groups_copyful_synth_injective ();
   extensionClientHello_extension_data_supported_groups_copyful_synth_inverse ();
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz namedGroupList_serializer write_namedGroupList fits_u64_squash) <: PPB.l2r_safe_writer _ extensionClientHello_extension_data_supported_groups'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 65535 65535ul 2 2sz namedGroupList_serializer write_namedGroupList) <: PPB.l2r_safe_writer _ extensionClientHello_extension_data_supported_groups'_serializer _)
     synth_extensionClientHello_extension_data_supported_groups synth_extensionClientHello_extension_data_supported_groups_recip
 
 let extensionClientHello_extension_data_supported_groups_bytesize_eqn x =

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_supported_groups.fsti
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_supported_groups.fsti
@@ -35,14 +35,14 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.NamedGroupList
 
-type extensionClientHello_extension_data_supported_groups = x:namedGroupList{let l = (namedGroupList_bytesize (x)) in 0 <= l /\ l <= 65535}
+noextract type extensionClientHello_extension_data_supported_groups = x:namedGroupList{let l = (namedGroupList_bytesize (x)) in 0 <= l /\ l <= 65535}
 
-type extensionClientHello_extension_data_supported_groups' = LP.parse_bounded_vldata_strong_t 0 65535 namedGroupList_serializer
+noextract type extensionClientHello_extension_data_supported_groups' = LP.parse_bounded_vldata_strong_t 0 65535 namedGroupList_serializer
 
-inline_for_extraction let synth_extensionClientHello_extension_data_supported_groups (x: extensionClientHello_extension_data_supported_groups') : Tot extensionClientHello_extension_data_supported_groups =
+inline_for_extraction noextract let synth_extensionClientHello_extension_data_supported_groups (x: extensionClientHello_extension_data_supported_groups') : Tot extensionClientHello_extension_data_supported_groups =
   [@inline_let] let _ = (namedGroupList_bytesize_eq (x)) in x
 
-inline_for_extraction let synth_extensionClientHello_extension_data_supported_groups_recip (x: extensionClientHello_extension_data_supported_groups) : Tot extensionClientHello_extension_data_supported_groups' =
+inline_for_extraction noextract let synth_extensionClientHello_extension_data_supported_groups_recip (x: extensionClientHello_extension_data_supported_groups) : Tot extensionClientHello_extension_data_supported_groups' =
   [@inline_let] let _ = (namedGroupList_bytesize_eq (x)) in x
 
 inline_for_extraction noextract let extensionClientHello_extension_data_supported_groups_parser_kind = LP.strong_parser_kind 6 65537 None

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_supported_versions.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_supported_versions.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let extensionClientHello_extension_data_supported_versions_parser =
   LP.parse_bounded_vldata 0 65535 supportedVersionsClientHello_parser
 
@@ -46,20 +44,20 @@ let extensionClientHello_extension_data_supported_versions_serializer =
 let extensionClientHello_extension_data_supported_versions_bytesize_eq x = ()
 
 let extensionClientHello_extension_data_supported_versions_validator =
-  PPVD.validate_bounded_vldata 0 65535 supportedVersionsClientHello_validator (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata 0 65535 supportedVersionsClientHello_validator (PPBI.leaf_read_bounded_integer_2 ())
 
 let extensionClientHello_extension_data_supported_versions_jumper =
-  PPVD.jump_bounded_vldata 0 65535 supportedVersionsClientHello_parser (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata 0 65535 supportedVersionsClientHello_parser (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let extensionClientHello_extension_data_supported_versions_accessor = PPVD.accessor_bounded_vldata_payload 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let extensionClientHello_extension_data_supported_versions_accessor = PPVD.accessor_bounded_vldata_payload 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let read_extensionClientHello_extension_data_supported_versions : PPB.copyful_parse extensionClientHello_extension_data_supported_versions_vmatch extensionClientHello_extension_data_supported_versions_parser extensionClientHello_extension_data_supported_versions_conv =
-  PPVD.copyful_parse_bounded_vldata_payload 0 65535 read_supportedVersionsClientHello (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.copyful_parse_bounded_vldata_payload 0 65535 read_supportedVersionsClientHello (PPBI.leaf_read_bounded_integer_2 ())
 
-let free_extensionClientHello_extension_data_supported_versions : PPB.free_t extensionClientHello_extension_data_supported_versions_vmatch = free_supportedVersionsClientHello
+let free_extensionClientHello_extension_data_supported_versions : PPB.free_t extensionClientHello_extension_data_supported_versions_vmatch = fun x #v -> (free_supportedVersionsClientHello) x #v
 
 let write_extensionClientHello_extension_data_supported_versions : PPB.l2r_safe_writer extensionClientHello_extension_data_supported_versions_vmatch extensionClientHello_extension_data_supported_versions_serializer extensionClientHello_extension_data_supported_versions_conv =
-  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0sz 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) supportedVersionsClientHello_serializer write_supportedVersionsClientHello fits_u64_squash
+  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0ul 65535 65535ul 2 2sz supportedVersionsClientHello_serializer write_supportedVersionsClientHello
 
 let extensionClientHello_extension_data_supported_versions_bytesize_eqn x =
   (supportedVersionsClientHello_bytesize_eq (x))

--- a/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_supported_versions.fsti
+++ b/generated/TLS13.Wire.Generated.ExtensionClientHello_extension_data_supported_versions.fsti
@@ -35,7 +35,7 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.SupportedVersionsClientHello
 
-type extensionClientHello_extension_data_supported_versions = supportedVersionsClientHello
+noextract type extensionClientHello_extension_data_supported_versions = supportedVersionsClientHello
 
 inline_for_extraction noextract let extensionClientHello_extension_data_supported_versions_parser_kind = LP.strong_parser_kind 5 257 None
 

--- a/generated/TLS13.Wire.Generated.ExtensionEncryptedExtensions.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionEncryptedExtensions.fst
@@ -37,8 +37,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 // Need high Z3 limits for large sum types
 #set-options "--z3rlimit 360"
 
@@ -170,7 +168,7 @@ noextract inline_for_extraction let synth_extensionEncryptedExtensions_cases_rec
       (match x with Extension_data_server_name y -> extensionEncryptedExtensions_known_case k' Server_name y)
    | _ -> [@inline_let] let _ = synth_extensionEncryptedExtensions_cases_recip_pre_intro (LP.Known k') in false_elim ()
 
-inline_for_extraction let extensionEncryptedExtensions_sum : LP.dsum = LP.make_dsum' extensionType_enum key_of_extensionEncryptedExtensions
+inline_for_extraction noextract let extensionEncryptedExtensions_sum : LP.dsum = LP.make_dsum' extensionType_enum key_of_extensionEncryptedExtensions
   extensionEncryptedExtensions_case_of_extensionType extensionEncryptedExtensions_extension_data_default synth_extensionEncryptedExtensions_cases synth_extensionEncryptedExtensions_cases_recip
   (_ by (LP.make_dsum_synth_case_recip_synth_case_known_tac ()))
   (_ by (LP.make_dsum_synth_case_recip_synth_case_unknown_tac ()))

--- a/generated/TLS13.Wire.Generated.ExtensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation'_parser : LP.parser _ extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation' =
   LP.parse_bounded_vldata_strong 0 65535 protocolNameList_serializer
 
@@ -50,12 +48,12 @@ let extensionEncryptedExtensions_extension_data_application_layer_protocol_negot
 let extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_bytesize_eq x = ()
 
 inline_for_extraction let extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation'_validator : LPS.validator extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation'_parser =
-  PPVD.validate_bounded_vldata_strong 0 65535 protocolNameList_serializer protocolNameList_validator (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 65535 protocolNameList_serializer protocolNameList_validator (PPBI.leaf_read_bounded_integer_2 ())
 
 let extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_validator = LPC.validate_synth extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation'_validator synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation
 
 inline_for_extraction let extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation'_jumper : LPS.jumper extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation'_parser =
-  PPVD.jump_bounded_vldata_strong 0 65535 protocolNameList_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 65535 protocolNameList_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_jumper = LPC.jump_synth extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation'_jumper synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation
 
@@ -63,7 +61,7 @@ let extensionEncryptedExtensions_extension_data_application_layer_protocol_negot
   PPC.accessor_ext
     (PPC.accessor_compose
       (PPC.accessor_synth synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_recip)
-      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 protocolNameList_serializer (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash) ())
+      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 protocolNameList_serializer (PPBI.leaf_read_bounded_integer_2 ())) ())
     extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_clens ()
 
 
@@ -75,7 +73,7 @@ let read_extensionEncryptedExtensions_extension_data_application_layer_protocol_
   extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_copyful_synth_injective ();
   extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_copyful_synth_inverse ();
   PPC.copyful_parse_synth
-    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 protocolNameList_serializer read_protocolNameList (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 protocolNameList_serializer read_protocolNameList (PPBI.leaf_read_bounded_integer_2 ()))
     synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_recip
 
 let free_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation : PPB.free_t extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_vmatch =
@@ -85,7 +83,7 @@ let write_extensionEncryptedExtensions_extension_data_application_layer_protocol
   extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_copyful_synth_injective ();
   extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_copyful_synth_inverse ();
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz protocolNameList_serializer write_protocolNameList fits_u64_squash) <: PPB.l2r_safe_writer _ extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 65535 65535ul 2 2sz protocolNameList_serializer write_protocolNameList) <: PPB.l2r_safe_writer _ extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation'_serializer _)
     synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_recip
 
 let extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_bytesize_eqn x =

--- a/generated/TLS13.Wire.Generated.ExtensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation.fsti
+++ b/generated/TLS13.Wire.Generated.ExtensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation.fsti
@@ -35,14 +35,14 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.ProtocolNameList
 
-type extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation = x:protocolNameList{let l = (protocolNameList_bytesize (x)) in 0 <= l /\ l <= 65535}
+noextract type extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation = x:protocolNameList{let l = (protocolNameList_bytesize (x)) in 0 <= l /\ l <= 65535}
 
-type extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation' = LP.parse_bounded_vldata_strong_t 0 65535 protocolNameList_serializer
+noextract type extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation' = LP.parse_bounded_vldata_strong_t 0 65535 protocolNameList_serializer
 
-inline_for_extraction let synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation (x: extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation') : Tot extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation =
+inline_for_extraction noextract let synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation (x: extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation') : Tot extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation =
   [@inline_let] let _ = (protocolNameList_bytesize_eq (x)) in x
 
-inline_for_extraction let synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_recip (x: extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation) : Tot extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation' =
+inline_for_extraction noextract let synth_extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_recip (x: extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation) : Tot extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation' =
   [@inline_let] let _ = (protocolNameList_bytesize_eq (x)) in x
 
 inline_for_extraction noextract let extensionEncryptedExtensions_extension_data_application_layer_protocol_negotiation_parser_kind = LP.strong_parser_kind 6 65537 None

--- a/generated/TLS13.Wire.Generated.ExtensionEncryptedExtensions_extension_data_default.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionEncryptedExtensions_extension_data_default.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionEncryptedExtensions_extension_data_default_parser = LP.parse_bounded_seq_vlbytes 0 65535
 
 noextract let extensionEncryptedExtensions_extension_data_default_serializer = LP.serialize_bounded_seq_vlbytes 0 65535
 
 let extensionEncryptedExtensions_extension_data_default_bytesize_eq x = ()
 
-let extensionEncryptedExtensions_extension_data_default_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let extensionEncryptedExtensions_extension_data_default_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
-let extensionEncryptedExtensions_extension_data_default_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let extensionEncryptedExtensions_extension_data_default_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_extensionEncryptedExtensions_extension_data_default = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_extensionEncryptedExtensions_extension_data_default = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_extensionEncryptedExtensions_extension_data_default : PPB.free_t extensionEncryptedExtensions_extension_data_default_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_extensionEncryptedExtensions_extension_data_default = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let write_extensionEncryptedExtensions_extension_data_default = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
-let size_extensionEncryptedExtensions_extension_data_default = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let size_extensionEncryptedExtensions_extension_data_default = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
 let extensionEncryptedExtensions_extension_data_default_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 65535 x
 

--- a/generated/TLS13.Wire.Generated.ExtensionServerHello.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionServerHello.fst
@@ -37,8 +37,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 // Need high Z3 limits for large sum types
 #set-options "--z3rlimit 360"
 
@@ -170,7 +168,7 @@ noextract inline_for_extraction let synth_extensionServerHello_cases_recip (k:LP
       (match x with Extension_data_server_name y -> extensionServerHello_known_case k' Server_name y)
    | _ -> [@inline_let] let _ = synth_extensionServerHello_cases_recip_pre_intro (LP.Known k') in false_elim ()
 
-inline_for_extraction let extensionServerHello_sum : LP.dsum = LP.make_dsum' extensionType_enum key_of_extensionServerHello
+inline_for_extraction noextract let extensionServerHello_sum : LP.dsum = LP.make_dsum' extensionType_enum key_of_extensionServerHello
   extensionServerHello_case_of_extensionType extensionServerHello_extension_data_default synth_extensionServerHello_cases synth_extensionServerHello_cases_recip
   (_ by (LP.make_dsum_synth_case_recip_synth_case_known_tac ()))
   (_ by (LP.make_dsum_synth_case_recip_synth_case_unknown_tac ()))

--- a/generated/TLS13.Wire.Generated.ExtensionServerHello_extension_data_default.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionServerHello_extension_data_default.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionServerHello_extension_data_default_parser = LP.parse_bounded_seq_vlbytes 0 65535
 
 noextract let extensionServerHello_extension_data_default_serializer = LP.serialize_bounded_seq_vlbytes 0 65535
 
 let extensionServerHello_extension_data_default_bytesize_eq x = ()
 
-let extensionServerHello_extension_data_default_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let extensionServerHello_extension_data_default_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
-let extensionServerHello_extension_data_default_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let extensionServerHello_extension_data_default_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_extensionServerHello_extension_data_default = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_extensionServerHello_extension_data_default = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_extensionServerHello_extension_data_default : PPB.free_t extensionServerHello_extension_data_default_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_extensionServerHello_extension_data_default = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let write_extensionServerHello_extension_data_default = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
-let size_extensionServerHello_extension_data_default = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let size_extensionServerHello_extension_data_default = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
 let extensionServerHello_extension_data_default_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 65535 x
 

--- a/generated/TLS13.Wire.Generated.ExtensionServerHello_extension_data_key_share.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionServerHello_extension_data_key_share.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionServerHello_extension_data_key_share'_parser : LP.parser _ extensionServerHello_extension_data_key_share' =
   LP.parse_bounded_vldata_strong 0 65535 keyShareServerHello_serializer
 
@@ -50,12 +48,12 @@ let extensionServerHello_extension_data_key_share_serializer = LP.serialize_synt
 let extensionServerHello_extension_data_key_share_bytesize_eq x = ()
 
 inline_for_extraction let extensionServerHello_extension_data_key_share'_validator : LPS.validator extensionServerHello_extension_data_key_share'_parser =
-  PPVD.validate_bounded_vldata_strong 0 65535 keyShareServerHello_serializer keyShareServerHello_validator (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 65535 keyShareServerHello_serializer keyShareServerHello_validator (PPBI.leaf_read_bounded_integer_2 ())
 
 let extensionServerHello_extension_data_key_share_validator = LPC.validate_synth extensionServerHello_extension_data_key_share'_validator synth_extensionServerHello_extension_data_key_share
 
 inline_for_extraction let extensionServerHello_extension_data_key_share'_jumper : LPS.jumper extensionServerHello_extension_data_key_share'_parser =
-  PPVD.jump_bounded_vldata_strong 0 65535 keyShareServerHello_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 65535 keyShareServerHello_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let extensionServerHello_extension_data_key_share_jumper = LPC.jump_synth extensionServerHello_extension_data_key_share'_jumper synth_extensionServerHello_extension_data_key_share
 
@@ -63,7 +61,7 @@ let extensionServerHello_extension_data_key_share_accessor =
   PPC.accessor_ext
     (PPC.accessor_compose
       (PPC.accessor_synth synth_extensionServerHello_extension_data_key_share synth_extensionServerHello_extension_data_key_share_recip)
-      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 keyShareServerHello_serializer (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash) ())
+      (PPVD.accessor_bounded_vldata_strong_payload 0 65535 keyShareServerHello_serializer (PPBI.leaf_read_bounded_integer_2 ())) ())
     extensionServerHello_extension_data_key_share_clens ()
 
 
@@ -75,7 +73,7 @@ let read_extensionServerHello_extension_data_key_share : PPB.copyful_parse exten
   extensionServerHello_extension_data_key_share_copyful_synth_injective ();
   extensionServerHello_extension_data_key_share_copyful_synth_inverse ();
   PPC.copyful_parse_synth
-    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 keyShareServerHello_serializer read_keyShareServerHello (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 keyShareServerHello_serializer read_keyShareServerHello (PPBI.leaf_read_bounded_integer_2 ()))
     synth_extensionServerHello_extension_data_key_share synth_extensionServerHello_extension_data_key_share_recip
 
 let free_extensionServerHello_extension_data_key_share : PPB.free_t extensionServerHello_extension_data_key_share_vmatch =
@@ -85,7 +83,7 @@ let write_extensionServerHello_extension_data_key_share : PPB.l2r_safe_writer ex
   extensionServerHello_extension_data_key_share_copyful_synth_injective ();
   extensionServerHello_extension_data_key_share_copyful_synth_inverse ();
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz keyShareServerHello_serializer write_keyShareServerHello fits_u64_squash) <: PPB.l2r_safe_writer _ extensionServerHello_extension_data_key_share'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 65535 65535ul 2 2sz keyShareServerHello_serializer write_keyShareServerHello) <: PPB.l2r_safe_writer _ extensionServerHello_extension_data_key_share'_serializer _)
     synth_extensionServerHello_extension_data_key_share synth_extensionServerHello_extension_data_key_share_recip
 
 let extensionServerHello_extension_data_key_share_bytesize_eqn x =

--- a/generated/TLS13.Wire.Generated.ExtensionServerHello_extension_data_key_share.fsti
+++ b/generated/TLS13.Wire.Generated.ExtensionServerHello_extension_data_key_share.fsti
@@ -35,14 +35,14 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.KeyShareServerHello
 
-type extensionServerHello_extension_data_key_share = x:keyShareServerHello{let l = (keyShareServerHello_bytesize (x)) in 0 <= l /\ l <= 65535}
+noextract type extensionServerHello_extension_data_key_share = x:keyShareServerHello{let l = (keyShareServerHello_bytesize (x)) in 0 <= l /\ l <= 65535}
 
-type extensionServerHello_extension_data_key_share' = LP.parse_bounded_vldata_strong_t 0 65535 keyShareServerHello_serializer
+noextract type extensionServerHello_extension_data_key_share' = LP.parse_bounded_vldata_strong_t 0 65535 keyShareServerHello_serializer
 
-inline_for_extraction let synth_extensionServerHello_extension_data_key_share (x: extensionServerHello_extension_data_key_share') : Tot extensionServerHello_extension_data_key_share =
+inline_for_extraction noextract let synth_extensionServerHello_extension_data_key_share (x: extensionServerHello_extension_data_key_share') : Tot extensionServerHello_extension_data_key_share =
   [@inline_let] let _ = (keyShareServerHello_bytesize_eq (x)) in x
 
-inline_for_extraction let synth_extensionServerHello_extension_data_key_share_recip (x: extensionServerHello_extension_data_key_share) : Tot extensionServerHello_extension_data_key_share' =
+inline_for_extraction noextract let synth_extensionServerHello_extension_data_key_share_recip (x: extensionServerHello_extension_data_key_share) : Tot extensionServerHello_extension_data_key_share' =
   [@inline_let] let _ = (keyShareServerHello_bytesize_eq (x)) in x
 
 inline_for_extraction noextract let extensionServerHello_extension_data_key_share_parser_kind = LP.strong_parser_kind 7 65537 None

--- a/generated/TLS13.Wire.Generated.ExtensionServerHello_extension_data_supported_versions.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionServerHello_extension_data_supported_versions.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let extensionServerHello_extension_data_supported_versions_parser =
   LP.parse_bounded_vldata 0 65535 supportedVersionsServerHello_parser
 
@@ -46,18 +44,18 @@ let extensionServerHello_extension_data_supported_versions_serializer =
 let extensionServerHello_extension_data_supported_versions_bytesize_eq x = ()
 
 let extensionServerHello_extension_data_supported_versions_validator =
-  PPVD.validate_bounded_vldata 0 65535 supportedVersionsServerHello_validator (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata 0 65535 supportedVersionsServerHello_validator (PPBI.leaf_read_bounded_integer_2 ())
 
-let extensionServerHello_extension_data_supported_versions_accessor = PPVD.accessor_bounded_vldata_payload 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let extensionServerHello_extension_data_supported_versions_accessor = PPVD.accessor_bounded_vldata_payload 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let read_extensionServerHello_extension_data_supported_versions : PPB.copyful_parse extensionServerHello_extension_data_supported_versions_vmatch extensionServerHello_extension_data_supported_versions_parser extensionServerHello_extension_data_supported_versions_conv =
-  PPVD.copyful_parse_bounded_vldata_payload 0 65535 read_supportedVersionsServerHello (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.copyful_parse_bounded_vldata_payload 0 65535 read_supportedVersionsServerHello (PPBI.leaf_read_bounded_integer_2 ())
 
-let free_extensionServerHello_extension_data_supported_versions : PPB.free_t extensionServerHello_extension_data_supported_versions_vmatch =
-  TLS13.Wire.Generated.ProtocolVersion.free_protocolVersion
+let free_extensionServerHello_extension_data_supported_versions : PPB.free_t extensionServerHello_extension_data_supported_versions_vmatch = fun x #v -> (free_supportedVersionsServerHello) x #v
 
 let write_extensionServerHello_extension_data_supported_versions : PPB.l2r_safe_writer extensionServerHello_extension_data_supported_versions_vmatch extensionServerHello_extension_data_supported_versions_serializer extensionServerHello_extension_data_supported_versions_conv =
-  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0sz 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) supportedVersionsServerHello_serializer write_supportedVersionsServerHello fits_u64_squash
+  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0ul 65535 65535ul 2 2sz supportedVersionsServerHello_serializer write_supportedVersionsServerHello
 
 let extensionServerHello_extension_data_supported_versions_bytesize_eqn x =
   (supportedVersionsServerHello_bytesize_eq (x))
+

--- a/generated/TLS13.Wire.Generated.ExtensionServerHello_extension_data_supported_versions.fsti
+++ b/generated/TLS13.Wire.Generated.ExtensionServerHello_extension_data_supported_versions.fsti
@@ -35,7 +35,7 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.SupportedVersionsServerHello
 
-type extensionServerHello_extension_data_supported_versions = supportedVersionsServerHello
+noextract type extensionServerHello_extension_data_supported_versions = supportedVersionsServerHello
 
 inline_for_extraction noextract let extensionServerHello_extension_data_supported_versions_parser_kind = LP.strong_parser_kind 4 4 None
 

--- a/generated/TLS13.Wire.Generated.ExtensionType.fst
+++ b/generated/TLS13.Wire.Generated.ExtensionType.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let extensionType_repr_parser = LPI.parse_u16
 
 noextract let extensionType_repr_serializer = LPI.serialize_u16
@@ -49,7 +47,7 @@ inline_for_extraction noextract let extensionType_repr_reader = (PPB.leaf_reader
 
 inline_for_extraction noextract let extensionType_repr_writer = (LPPI.l2r_leaf_write_u16 ())
 
-inline_for_extraction let synth_extensionType (x:LP.maybe_enum_key extensionType_enum) : extensionType = 
+inline_for_extraction noextract let synth_extensionType (x:LP.maybe_enum_key extensionType_enum) : extensionType = 
   match x with
   | LP.Known k -> k
   | LP.Unknown y ->
@@ -57,7 +55,7 @@ inline_for_extraction let synth_extensionType (x:LP.maybe_enum_key extensionType
     [@inline_let] let _ = assert_norm (LP.list_mem v (LP.list_map snd extensionType_enum) == known_extensionType_repr v) in
     Unknown_extensionType v
 
-inline_for_extraction let synth_extensionType_inv (x:extensionType) : LP.maybe_enum_key extensionType_enum = 
+inline_for_extraction noextract let synth_extensionType_inv (x:extensionType) : LP.maybe_enum_key extensionType_enum = 
   match x with
   | Unknown_extensionType y ->
     [@inline_let] let v : U16.t = y in

--- a/generated/TLS13.Wire.Generated.Finished.fst
+++ b/generated/TLS13.Wire.Generated.Finished.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let finished_parser = LP.parse_lseq_bytes 32
 
 noextract let finished_serializer = LP.serialize_lseq_bytes 32

--- a/generated/TLS13.Wire.Generated.Handshake.fst
+++ b/generated/TLS13.Wire.Generated.Handshake.fst
@@ -37,8 +37,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 // Need high Z3 limits for large sum types
 #set-options "--z3rlimit 480"
 
@@ -125,7 +123,7 @@ noextract inline_for_extraction let synth_handshake_cases_recip (k:LP.enum_key h
   | New_session_ticket -> [@inline_let] let _ = synth_handshake_cases_recip_pre_intro New_session_ticket x in
     (match x with Body_new_session_ticket y -> (from_handshake_case_of_handshakeType New_session_ticket y))
 
-inline_for_extraction let handshake_sum = LP.make_sum' handshakeType_enum key_of_handshake
+inline_for_extraction noextract let handshake_sum = LP.make_sum' handshakeType_enum key_of_handshake
   handshake_case_of_handshakeType synth_handshake_cases synth_handshake_cases_recip
   (_ by (LP.make_sum_synth_case_recip_synth_case_tac ()))
   (_ by (LP.synth_case_synth_case_recip_tac ()))

--- a/generated/TLS13.Wire.Generated.HandshakeType.fst
+++ b/generated/TLS13.Wire.Generated.HandshakeType.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let handshakeType_repr_parser = LPI.parse_u8
 
 noextract let handshakeType_repr_serializer = LPI.serialize_u8
@@ -49,9 +47,9 @@ inline_for_extraction noextract let handshakeType_repr_reader = (PPB.leaf_reader
 
 inline_for_extraction noextract let handshakeType_repr_writer = (LPPI.l2r_leaf_write_u8 ())
 
-inline_for_extraction let synth_handshakeType (x: LP.enum_key handshakeType_enum) : Tot handshakeType = x
+inline_for_extraction noextract let synth_handshakeType (x: LP.enum_key handshakeType_enum) : Tot handshakeType = x
 
-inline_for_extraction let synth_handshakeType_inv (x: handshakeType) : Tot (LP.enum_key handshakeType_enum) =
+inline_for_extraction noextract let synth_handshakeType_inv (x: handshakeType) : Tot (LP.enum_key handshakeType_enum) =
   [@inline_let] let _ : squash (LP.list_mem x (LP.list_map fst handshakeType_enum)) =
     _ by (LP.synth_maybe_enum_key_inv_unknown_tac x)
   in

--- a/generated/TLS13.Wire.Generated.Handshake_body_certificate.fst
+++ b/generated/TLS13.Wire.Generated.Handshake_body_certificate.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let handshake_body_certificate'_parser : LP.parser _ handshake_body_certificate' =
   LP.parse_bounded_vldata_strong 0 16777215 certificate_serializer
 
@@ -50,12 +48,12 @@ let handshake_body_certificate_serializer = LP.serialize_synth _ synth_handshake
 let handshake_body_certificate_bytesize_eq x = ()
 
 inline_for_extraction let handshake_body_certificate'_validator : LPS.validator handshake_body_certificate'_parser =
-  PPVD.validate_bounded_vldata_strong 0 16777215 certificate_serializer certificate_validator (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 16777215 certificate_serializer certificate_validator (PPBI.leaf_read_bounded_integer_3 ())
 
 let handshake_body_certificate_validator = LPC.validate_synth handshake_body_certificate'_validator synth_handshake_body_certificate
 
 inline_for_extraction let handshake_body_certificate'_jumper : LPS.jumper handshake_body_certificate'_parser =
-  PPVD.jump_bounded_vldata_strong 0 16777215 certificate_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 16777215 certificate_serializer (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 ()))
 
 let handshake_body_certificate_jumper = LPC.jump_synth handshake_body_certificate'_jumper synth_handshake_body_certificate
 
@@ -63,7 +61,7 @@ let handshake_body_certificate_accessor =
   PPC.accessor_ext
     (PPC.accessor_compose
       (PPC.accessor_synth synth_handshake_body_certificate synth_handshake_body_certificate_recip)
-      (PPVD.accessor_bounded_vldata_strong_payload 0 16777215 certificate_serializer (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash) ())
+      (PPVD.accessor_bounded_vldata_strong_payload 0 16777215 certificate_serializer (PPBI.leaf_read_bounded_integer_3 ())) ())
     handshake_body_certificate_clens ()
 
 
@@ -75,7 +73,7 @@ let read_handshake_body_certificate : PPB.copyful_parse handshake_body_certifica
   handshake_body_certificate_copyful_synth_injective ();
   handshake_body_certificate_copyful_synth_inverse ();
   PPC.copyful_parse_synth
-    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 16777215 certificate_serializer read_certificate (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash)
+    (PPVD.copyful_parse_bounded_vldata_strong_payload 0 16777215 certificate_serializer read_certificate (PPBI.leaf_read_bounded_integer_3 ()))
     synth_handshake_body_certificate synth_handshake_body_certificate_recip
 
 let free_handshake_body_certificate : PPB.free_t handshake_body_certificate_vmatch =
@@ -85,7 +83,7 @@ let write_handshake_body_certificate : PPB.l2r_safe_writer handshake_body_certif
   handshake_body_certificate_copyful_synth_injective ();
   handshake_body_certificate_copyful_synth_inverse ();
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 16777215 (LSeqB.mk_seq_sizet 16777215 fits_u64_squash) 3 3sz certificate_serializer write_certificate fits_u64_squash) <: PPB.l2r_safe_writer _ handshake_body_certificate'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 16777215 16777215ul 3 3sz certificate_serializer write_certificate) <: PPB.l2r_safe_writer _ handshake_body_certificate'_serializer _)
     synth_handshake_body_certificate synth_handshake_body_certificate_recip
 
 let handshake_body_certificate_bytesize_eqn x =

--- a/generated/TLS13.Wire.Generated.Handshake_body_certificate.fsti
+++ b/generated/TLS13.Wire.Generated.Handshake_body_certificate.fsti
@@ -35,14 +35,14 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.Certificate
 
-type handshake_body_certificate = x:certificate{let l = (certificate_bytesize (x)) in 0 <= l /\ l <= 16777215}
+noextract type handshake_body_certificate = x:certificate{let l = (certificate_bytesize (x)) in 0 <= l /\ l <= 16777215}
 
-type handshake_body_certificate' = LP.parse_bounded_vldata_strong_t 0 16777215 certificate_serializer
+noextract type handshake_body_certificate' = LP.parse_bounded_vldata_strong_t 0 16777215 certificate_serializer
 
-inline_for_extraction let synth_handshake_body_certificate (x: handshake_body_certificate') : Tot handshake_body_certificate =
+inline_for_extraction noextract let synth_handshake_body_certificate (x: handshake_body_certificate') : Tot handshake_body_certificate =
   [@inline_let] let _ = (certificate_bytesize_eq (x)) in x
 
-inline_for_extraction let synth_handshake_body_certificate_recip (x: handshake_body_certificate) : Tot handshake_body_certificate' =
+inline_for_extraction noextract let synth_handshake_body_certificate_recip (x: handshake_body_certificate) : Tot handshake_body_certificate' =
   [@inline_let] let _ = (certificate_bytesize_eq (x)) in x
 
 inline_for_extraction noextract let handshake_body_certificate_parser_kind = LP.strong_parser_kind 7 16777218 None

--- a/generated/TLS13.Wire.Generated.Handshake_body_certificate_verify.fst
+++ b/generated/TLS13.Wire.Generated.Handshake_body_certificate_verify.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let handshake_body_certificate_verify_parser =
   LP.parse_bounded_vldata 0 16777215 certificateVerify_parser
 
@@ -46,20 +44,20 @@ let handshake_body_certificate_verify_serializer =
 let handshake_body_certificate_verify_bytesize_eq x = ()
 
 let handshake_body_certificate_verify_validator =
-  PPVD.validate_bounded_vldata 0 16777215 certificateVerify_validator (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata 0 16777215 certificateVerify_validator (PPBI.leaf_read_bounded_integer_3 ())
 
 let handshake_body_certificate_verify_jumper =
-  PPVD.jump_bounded_vldata 0 16777215 certificateVerify_parser (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata 0 16777215 certificateVerify_parser (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 ()))
 
-let handshake_body_certificate_verify_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+let handshake_body_certificate_verify_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 ())
 
 let read_handshake_body_certificate_verify : PPB.copyful_parse handshake_body_certificate_verify_vmatch handshake_body_certificate_verify_parser handshake_body_certificate_verify_conv =
-  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_certificateVerify (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_certificateVerify (PPBI.leaf_read_bounded_integer_3 ())
 
-let free_handshake_body_certificate_verify : PPB.free_t handshake_body_certificate_verify_vmatch = free_certificateVerify
+let free_handshake_body_certificate_verify : PPB.free_t handshake_body_certificate_verify_vmatch = fun x #v -> (free_certificateVerify) x #v
 
 let write_handshake_body_certificate_verify : PPB.l2r_safe_writer handshake_body_certificate_verify_vmatch handshake_body_certificate_verify_serializer handshake_body_certificate_verify_conv =
-  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0sz 16777215 (LSeqB.mk_seq_sizet 16777215 fits_u64_squash) certificateVerify_serializer write_certificateVerify fits_u64_squash
+  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0ul 16777215 16777215ul 3 3sz certificateVerify_serializer write_certificateVerify
 
 let handshake_body_certificate_verify_bytesize_eqn x =
   (certificateVerify_bytesize_eq (x))

--- a/generated/TLS13.Wire.Generated.Handshake_body_certificate_verify.fsti
+++ b/generated/TLS13.Wire.Generated.Handshake_body_certificate_verify.fsti
@@ -35,7 +35,7 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.CertificateVerify
 
-type handshake_body_certificate_verify = certificateVerify
+noextract type handshake_body_certificate_verify = certificateVerify
 
 inline_for_extraction noextract let handshake_body_certificate_verify_parser_kind = LP.strong_parser_kind 7 65542 None
 

--- a/generated/TLS13.Wire.Generated.Handshake_body_client_hello.fst
+++ b/generated/TLS13.Wire.Generated.Handshake_body_client_hello.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let handshake_body_client_hello_parser =
   LP.parse_bounded_vldata 0 16777215 clientHello_parser
 
@@ -46,20 +44,20 @@ let handshake_body_client_hello_serializer =
 let handshake_body_client_hello_bytesize_eq x = ()
 
 let handshake_body_client_hello_validator =
-  PPVD.validate_bounded_vldata 0 16777215 clientHello_validator (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata 0 16777215 clientHello_validator (PPBI.leaf_read_bounded_integer_3 ())
 
 let handshake_body_client_hello_jumper =
-  PPVD.jump_bounded_vldata 0 16777215 clientHello_parser (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata 0 16777215 clientHello_parser (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 ()))
 
-let handshake_body_client_hello_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+let handshake_body_client_hello_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 ())
 
 let read_handshake_body_client_hello : PPB.copyful_parse handshake_body_client_hello_vmatch handshake_body_client_hello_parser handshake_body_client_hello_conv =
-  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_clientHello (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_clientHello (PPBI.leaf_read_bounded_integer_3 ())
 
-let free_handshake_body_client_hello : PPB.free_t handshake_body_client_hello_vmatch = free_clientHello
+let free_handshake_body_client_hello : PPB.free_t handshake_body_client_hello_vmatch = fun x #v -> (free_clientHello) x #v
 
 let write_handshake_body_client_hello : PPB.l2r_safe_writer handshake_body_client_hello_vmatch handshake_body_client_hello_serializer handshake_body_client_hello_conv =
-  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0sz 16777215 (LSeqB.mk_seq_sizet 16777215 fits_u64_squash) clientHello_serializer write_clientHello fits_u64_squash
+  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0ul 16777215 16777215ul 3 3sz clientHello_serializer write_clientHello
 
 let handshake_body_client_hello_bytesize_eqn x =
   (clientHello_bytesize_eq (x))

--- a/generated/TLS13.Wire.Generated.Handshake_body_client_hello.fsti
+++ b/generated/TLS13.Wire.Generated.Handshake_body_client_hello.fsti
@@ -35,7 +35,7 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.ClientHello
 
-type handshake_body_client_hello = clientHello
+noextract type handshake_body_client_hello = clientHello
 
 inline_for_extraction noextract let handshake_body_client_hello_parser_kind = LP.strong_parser_kind 54 131399 None
 

--- a/generated/TLS13.Wire.Generated.Handshake_body_encrypted_extensions.fst
+++ b/generated/TLS13.Wire.Generated.Handshake_body_encrypted_extensions.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let handshake_body_encrypted_extensions_parser =
   LP.parse_bounded_vldata 0 16777215 encryptedExtensions_parser
 
@@ -46,20 +44,20 @@ let handshake_body_encrypted_extensions_serializer =
 let handshake_body_encrypted_extensions_bytesize_eq x = ()
 
 let handshake_body_encrypted_extensions_validator =
-  PPVD.validate_bounded_vldata 0 16777215 encryptedExtensions_validator (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata 0 16777215 encryptedExtensions_validator (PPBI.leaf_read_bounded_integer_3 ())
 
 let handshake_body_encrypted_extensions_jumper =
-  PPVD.jump_bounded_vldata 0 16777215 encryptedExtensions_parser (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata 0 16777215 encryptedExtensions_parser (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 ()))
 
-let handshake_body_encrypted_extensions_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+let handshake_body_encrypted_extensions_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 ())
 
 let read_handshake_body_encrypted_extensions : PPB.copyful_parse handshake_body_encrypted_extensions_vmatch handshake_body_encrypted_extensions_parser handshake_body_encrypted_extensions_conv =
-  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_encryptedExtensions (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_encryptedExtensions (PPBI.leaf_read_bounded_integer_3 ())
 
-let free_handshake_body_encrypted_extensions : PPB.free_t handshake_body_encrypted_extensions_vmatch = free_encryptedExtensions
+let free_handshake_body_encrypted_extensions : PPB.free_t handshake_body_encrypted_extensions_vmatch = fun x #v -> (free_encryptedExtensions) x #v
 
 let write_handshake_body_encrypted_extensions : PPB.l2r_safe_writer handshake_body_encrypted_extensions_vmatch handshake_body_encrypted_extensions_serializer handshake_body_encrypted_extensions_conv =
-  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0sz 16777215 (LSeqB.mk_seq_sizet 16777215 fits_u64_squash) encryptedExtensions_serializer write_encryptedExtensions fits_u64_squash
+  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0ul 16777215 16777215ul 3 3sz encryptedExtensions_serializer write_encryptedExtensions
 
 let handshake_body_encrypted_extensions_bytesize_eqn x =
   (encryptedExtensions_bytesize_eq (x))

--- a/generated/TLS13.Wire.Generated.Handshake_body_encrypted_extensions.fsti
+++ b/generated/TLS13.Wire.Generated.Handshake_body_encrypted_extensions.fsti
@@ -35,7 +35,7 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.EncryptedExtensions
 
-type handshake_body_encrypted_extensions = encryptedExtensions
+noextract type handshake_body_encrypted_extensions = encryptedExtensions
 
 inline_for_extraction noextract let handshake_body_encrypted_extensions_parser_kind = LP.strong_parser_kind 5 65540 None
 

--- a/generated/TLS13.Wire.Generated.Handshake_body_finished.fst
+++ b/generated/TLS13.Wire.Generated.Handshake_body_finished.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let handshake_body_finished_parser =
   LP.parse_bounded_vldata 0 16777215 finished_parser
 
@@ -46,17 +44,17 @@ let handshake_body_finished_serializer =
 let handshake_body_finished_bytesize_eq x = ()
 
 let handshake_body_finished_validator =
-  PPVD.validate_bounded_vldata 0 16777215 finished_validator (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata 0 16777215 finished_validator (PPBI.leaf_read_bounded_integer_3 ())
 
-let handshake_body_finished_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+let handshake_body_finished_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 ())
 
 let read_handshake_body_finished : PPB.copyful_parse handshake_body_finished_vmatch handshake_body_finished_parser handshake_body_finished_conv =
-  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_finished (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_finished (PPBI.leaf_read_bounded_integer_3 ())
 
-let free_handshake_body_finished : PPB.free_t handshake_body_finished_vmatch = free_finished
+let free_handshake_body_finished : PPB.free_t handshake_body_finished_vmatch = fun x #v -> (free_finished) x #v
 
 let write_handshake_body_finished : PPB.l2r_safe_writer handshake_body_finished_vmatch handshake_body_finished_serializer handshake_body_finished_conv =
-  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0sz 16777215 (LSeqB.mk_seq_sizet 16777215 fits_u64_squash) finished_serializer write_finished fits_u64_squash
+  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0ul 16777215 16777215ul 3 3sz finished_serializer write_finished
 
 let handshake_body_finished_bytesize_eqn x =
   (finished_bytesize_eq (x))

--- a/generated/TLS13.Wire.Generated.Handshake_body_finished.fsti
+++ b/generated/TLS13.Wire.Generated.Handshake_body_finished.fsti
@@ -35,7 +35,7 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.Finished
 
-type handshake_body_finished = finished
+noextract type handshake_body_finished = finished
 
 inline_for_extraction noextract let handshake_body_finished_parser_kind = LP.strong_parser_kind 35 35 None
 

--- a/generated/TLS13.Wire.Generated.Handshake_body_key_update.fst
+++ b/generated/TLS13.Wire.Generated.Handshake_body_key_update.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let handshake_body_key_update_parser =
   LP.parse_bounded_vldata 0 16777215 keyUpdate_parser
 
@@ -46,18 +44,18 @@ let handshake_body_key_update_serializer =
 let handshake_body_key_update_bytesize_eq x = ()
 
 let handshake_body_key_update_validator =
-  PPVD.validate_bounded_vldata 0 16777215 keyUpdate_validator (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata 0 16777215 keyUpdate_validator (PPBI.leaf_read_bounded_integer_3 ())
 
-let handshake_body_key_update_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+let handshake_body_key_update_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 ())
 
 let read_handshake_body_key_update : PPB.copyful_parse handshake_body_key_update_vmatch handshake_body_key_update_parser handshake_body_key_update_conv =
-  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_keyUpdate (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_keyUpdate (PPBI.leaf_read_bounded_integer_3 ())
 
-let free_handshake_body_key_update : PPB.free_t handshake_body_key_update_vmatch =
-  TLS13.Wire.Generated.KeyUpdateRequest.free_keyUpdateRequest
+let free_handshake_body_key_update : PPB.free_t handshake_body_key_update_vmatch = fun x #v -> (free_keyUpdate) x #v
 
 let write_handshake_body_key_update : PPB.l2r_safe_writer handshake_body_key_update_vmatch handshake_body_key_update_serializer handshake_body_key_update_conv =
-  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0sz 16777215 (LSeqB.mk_seq_sizet 16777215 fits_u64_squash) keyUpdate_serializer write_keyUpdate fits_u64_squash
+  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0ul 16777215 16777215ul 3 3sz keyUpdate_serializer write_keyUpdate
 
 let handshake_body_key_update_bytesize_eqn x =
   (keyUpdate_bytesize_eq (x))
+

--- a/generated/TLS13.Wire.Generated.Handshake_body_key_update.fsti
+++ b/generated/TLS13.Wire.Generated.Handshake_body_key_update.fsti
@@ -35,7 +35,7 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.KeyUpdate
 
-type handshake_body_key_update = keyUpdate
+noextract type handshake_body_key_update = keyUpdate
 
 inline_for_extraction noextract let handshake_body_key_update_parser_kind = LP.strong_parser_kind 4 4 None
 

--- a/generated/TLS13.Wire.Generated.Handshake_body_server_hello.fst
+++ b/generated/TLS13.Wire.Generated.Handshake_body_server_hello.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let handshake_body_server_hello_parser =
   LP.parse_bounded_vldata 0 16777215 serverHello_parser
 
@@ -46,20 +44,20 @@ let handshake_body_server_hello_serializer =
 let handshake_body_server_hello_bytesize_eq x = ()
 
 let handshake_body_server_hello_validator =
-  PPVD.validate_bounded_vldata 0 16777215 serverHello_validator (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata 0 16777215 serverHello_validator (PPBI.leaf_read_bounded_integer_3 ())
 
 let handshake_body_server_hello_jumper =
-  PPVD.jump_bounded_vldata 0 16777215 serverHello_parser (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata 0 16777215 serverHello_parser (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16777215)) (PPBI.leaf_read_bounded_integer_3 ()))
 
-let handshake_body_server_hello_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+let handshake_body_server_hello_accessor = PPVD.accessor_bounded_vldata_payload 0 16777215 (PPBI.leaf_read_bounded_integer_3 ())
 
 let read_handshake_body_server_hello : PPB.copyful_parse handshake_body_server_hello_vmatch handshake_body_server_hello_parser handshake_body_server_hello_conv =
-  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_serverHello (PPBI.leaf_read_bounded_integer_3 fits_u64_squash) fits_u64_squash
+  PPVD.copyful_parse_bounded_vldata_payload 0 16777215 read_serverHello (PPBI.leaf_read_bounded_integer_3 ())
 
-let free_handshake_body_server_hello : PPB.free_t handshake_body_server_hello_vmatch = free_serverHello
+let free_handshake_body_server_hello : PPB.free_t handshake_body_server_hello_vmatch = fun x #v -> (free_serverHello) x #v
 
 let write_handshake_body_server_hello : PPB.l2r_safe_writer handshake_body_server_hello_vmatch handshake_body_server_hello_serializer handshake_body_server_hello_conv =
-  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0sz 16777215 (LSeqB.mk_seq_sizet 16777215 fits_u64_squash) serverHello_serializer write_serverHello fits_u64_squash
+  PPVD.l2r_safe_writer_bounded_vldata_payload 0 0ul 16777215 16777215ul 3 3sz serverHello_serializer write_serverHello
 
 let handshake_body_server_hello_bytesize_eqn x =
   (serverHello_bytesize_eq (x))

--- a/generated/TLS13.Wire.Generated.Handshake_body_server_hello.fsti
+++ b/generated/TLS13.Wire.Generated.Handshake_body_server_hello.fsti
@@ -35,7 +35,7 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.ServerHello
 
-type handshake_body_server_hello = serverHello
+noextract type handshake_body_server_hello = serverHello
 
 inline_for_extraction noextract let handshake_body_server_hello_parser_kind = LP.strong_parser_kind 49 65610 None
 

--- a/generated/TLS13.Wire.Generated.HostName.fst
+++ b/generated/TLS13.Wire.Generated.HostName.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let hostName_parser = LP.parse_bounded_seq_vlbytes 1 65535
 
 noextract let hostName_serializer = LP.serialize_bounded_seq_vlbytes 1 65535
 
 let hostName_bytesize_eq x = ()
 
-let hostName_validator = LSeqB.validate_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let hostName_validator = LSeqB.validate_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
-let hostName_jumper = LSeqB.jump_bounded_seq_vlbytes 1 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let hostName_jumper = LSeqB.jump_bounded_seq_vlbytes 1 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_hostName = LSeqB.copyful_parse_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_hostName = LSeqB.copyful_parse_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_hostName : PPB.free_t hostName_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_hostName = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let write_hostName = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 1ul 65535 65535ul 2sz
 
-let size_hostName = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let size_hostName = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 1ul 65535 65535ul 2sz
 
 let hostName_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 1 65535 x
 

--- a/generated/TLS13.Wire.Generated.KeyShareClientHello.fst
+++ b/generated/TLS13.Wire.Generated.KeyShareClientHello.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let keyShareClientHello_list_bytesize_nil = LP.serialize_list_nil keyShareEntry_parser keyShareEntry_serializer
 
 let keyShareClientHello_list_bytesize_cons x y = LP.serialize_list_cons keyShareEntry_parser keyShareEntry_serializer x y; (keyShareEntry_bytesize_eq (x))
@@ -54,12 +52,12 @@ let keyShareClientHello_serializer = LP.serialize_synth _ synth_keyShareClientHe
 let keyShareClientHello_bytesize_eq x = ()
 
 inline_for_extraction let keyShareClientHello'_validator : LPS.validator keyShareClientHello'_parser =
-  PPVD.validate_bounded_vldata_strong 0 65535 (LP.serialize_list _ keyShareEntry_serializer) (PPLS.validate_list keyShareEntry_validator ()) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 0 65535 (LP.serialize_list _ keyShareEntry_serializer) (PPLS.validate_list keyShareEntry_validator ()) (PPBI.leaf_read_bounded_integer_2 ())
 
 let keyShareClientHello_validator = LPC.validate_synth keyShareClientHello'_validator synth_keyShareClientHello
 
 inline_for_extraction let keyShareClientHello'_jumper : LPS.jumper keyShareClientHello'_parser =
-  PPVD.jump_bounded_vldata_strong 0 65535 (LP.serialize_list _ keyShareEntry_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 0 65535 (LP.serialize_list _ keyShareEntry_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let keyShareClientHello_jumper = LPC.jump_synth keyShareClientHello'_jumper synth_keyShareClientHello
 
@@ -76,7 +74,7 @@ let read_keyShareClientHello : PPB.copyful_parse keyShareClientHello_vmatch keyS
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 0 65535 (LP.serialize_list _ keyShareEntry_serializer)
        (PPLS.copyful_parse_list read_keyShareEntry keyShareEntry_jumper ())
-       (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_2 ()))
     synth_keyShareClientHello synth_keyShareClientHello_recip
 
 let free_keyShareClientHello : PPB.free_t keyShareClientHello_vmatch =
@@ -88,7 +86,7 @@ let write_keyShareClientHello : PPB.l2r_safe_writer keyShareClientHello_vmatch k
   assert_norm ((LP.get_parser_kind keyShareEntry_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind keyShareEntry_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz (LP.serialize_list _ keyShareEntry_serializer)
-       (PPLS.l2r_safe_writer_list keyShareEntry_serializer write_keyShareEntry ()) fits_u64_squash) <: PPB.l2r_safe_writer _ keyShareClientHello'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 0 0ul 65535 65535ul 2 2sz (LP.serialize_list _ keyShareEntry_serializer)
+       (PPLS.l2r_safe_writer_list keyShareEntry_serializer write_keyShareEntry ())) <: PPB.l2r_safe_writer _ keyShareClientHello'_serializer _)
     synth_keyShareClientHello synth_keyShareClientHello_recip
 

--- a/generated/TLS13.Wire.Generated.KeyShareEntry.fst
+++ b/generated/TLS13.Wire.Generated.KeyShareEntry.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 (* Type of field key_exchange*)
 open TLS13.Wire.Generated.KeyShareEntry_key_exchange
 
@@ -91,7 +89,7 @@ let read_keyShareEntry : PPB.copyful_parse keyShareEntry_vmatch keyShareEntry_pa
   assert_norm (keyShareEntry_parser_kind == keyShareEntry'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair namedGroup_jumper read_namedGroup () read_keyShareEntry_key_exchange) synth_keyShareEntry synth_keyShareEntry_recip
 
-let free_keyShareEntry : PPB.free_t keyShareEntry_vmatch = (PPC.free_pair free_namedGroup free_keyShareEntry_key_exchange)
+let free_keyShareEntry : PPB.free_t keyShareEntry_vmatch = fun x #v -> ((PPC.free_pair free_namedGroup free_keyShareEntry_key_exchange)) x #v
 
 let write_keyShareEntry : PPB.l2r_safe_writer keyShareEntry_vmatch keyShareEntry_serializer keyShareEntry_conv =
   synth_keyShareEntry_injective ();
@@ -100,7 +98,7 @@ let write_keyShareEntry : PPB.l2r_safe_writer keyShareEntry_vmatch keyShareEntry
 
 let size_keyShareEntry : PPB.l2r_safe_size keyShareEntry_vmatch keyShareEntry_serializer keyShareEntry_conv =
   synth_keyShareEntry_injective ();
-  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair fits_u64_squash size_namedGroup () size_keyShareEntry_key_exchange) synth_keyShareEntry synth_keyShareEntry_recip
+  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair size_namedGroup () size_keyShareEntry_key_exchange) synth_keyShareEntry synth_keyShareEntry_recip
 
 let keyShareEntry_bytesize_eqn x =
   [@inline_let] let _ = synth_keyShareEntry_injective () in

--- a/generated/TLS13.Wire.Generated.KeyShareEntry_key_exchange.fst
+++ b/generated/TLS13.Wire.Generated.KeyShareEntry_key_exchange.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let keyShareEntry_key_exchange_parser = LP.parse_bounded_seq_vlbytes 1 65535
 
 noextract let keyShareEntry_key_exchange_serializer = LP.serialize_bounded_seq_vlbytes 1 65535
 
 let keyShareEntry_key_exchange_bytesize_eq x = ()
 
-let keyShareEntry_key_exchange_validator = LSeqB.validate_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let keyShareEntry_key_exchange_validator = LSeqB.validate_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
-let keyShareEntry_key_exchange_jumper = LSeqB.jump_bounded_seq_vlbytes 1 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let keyShareEntry_key_exchange_jumper = LSeqB.jump_bounded_seq_vlbytes 1 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_keyShareEntry_key_exchange = LSeqB.copyful_parse_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_keyShareEntry_key_exchange = LSeqB.copyful_parse_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_keyShareEntry_key_exchange : PPB.free_t keyShareEntry_key_exchange_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_keyShareEntry_key_exchange = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let write_keyShareEntry_key_exchange = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 1ul 65535 65535ul 2sz
 
-let size_keyShareEntry_key_exchange = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let size_keyShareEntry_key_exchange = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 1ul 65535 65535ul 2sz
 
 let keyShareEntry_key_exchange_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 1 65535 x
 

--- a/generated/TLS13.Wire.Generated.KeyShareServerHello.fst
+++ b/generated/TLS13.Wire.Generated.KeyShareServerHello.fst
@@ -35,23 +35,21 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let keyShareServerHello_parser = keyShareEntry_parser
 
 noextract let keyShareServerHello_serializer = keyShareEntry_serializer
 
 let keyShareServerHello_bytesize_eq x = ()
 
-let keyShareServerHello_validator = keyShareEntry_validator
+let keyShareServerHello_validator = fun input poffset #offset #pm #v -> (keyShareEntry_validator) input poffset #offset #pm #v
 
-let keyShareServerHello_jumper = keyShareEntry_jumper
+let keyShareServerHello_jumper = fun input offset #pm #v -> (keyShareEntry_jumper) input offset #pm #v
 
-let read_keyShareServerHello : PPB.copyful_parse keyShareServerHello_vmatch keyShareServerHello_parser keyShareServerHello_conv = read_keyShareEntry
+let read_keyShareServerHello : PPB.copyful_parse keyShareServerHello_vmatch keyShareServerHello_parser keyShareServerHello_conv = fun input #pm #v -> (read_keyShareEntry) input #pm #v
 
-let free_keyShareServerHello : PPB.free_t keyShareServerHello_vmatch = free_keyShareEntry
+let free_keyShareServerHello : PPB.free_t keyShareServerHello_vmatch = fun x #v -> (free_keyShareEntry) x #v
 
-let write_keyShareServerHello : PPB.l2r_safe_writer keyShareServerHello_vmatch keyShareServerHello_serializer keyShareServerHello_conv = write_keyShareEntry
+let write_keyShareServerHello : PPB.l2r_safe_writer keyShareServerHello_vmatch keyShareServerHello_serializer keyShareServerHello_conv = fun x #y out #v perr -> (write_keyShareEntry) x #y out #v perr
 
 let keyShareServerHello_bytesize_eqn x = (keyShareEntry_bytesize_eq (x))
 

--- a/generated/TLS13.Wire.Generated.KeyShareServerHello.fsti
+++ b/generated/TLS13.Wire.Generated.KeyShareServerHello.fsti
@@ -35,7 +35,7 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 open TLS13.Wire.Generated.KeyShareEntry
 
-type keyShareServerHello = keyShareEntry
+noextract type keyShareServerHello = keyShareEntry
 
 inline_for_extraction noextract let keyShareServerHello_parser_kind = LP.strong_parser_kind 5 65539 None
 

--- a/generated/TLS13.Wire.Generated.KeyUpdate.fst
+++ b/generated/TLS13.Wire.Generated.KeyUpdate.fst
@@ -35,27 +35,25 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let keyUpdate_parser = keyUpdateRequest_parser
 
 noextract let keyUpdate_serializer = keyUpdateRequest_serializer
 
 let keyUpdate_bytesize_eq x = ()
 
-let keyUpdate_validator = keyUpdateRequest_validator
+let keyUpdate_validator = fun input poffset #offset #pm #v -> (keyUpdateRequest_validator) input poffset #offset #pm #v
 
-let keyUpdate_reader = keyUpdateRequest_reader
+let keyUpdate_reader = fun input #pm #v -> (keyUpdateRequest_reader) input #pm #v
 
-let keyUpdate_writer = keyUpdateRequest_writer
+let keyUpdate_writer = fun x out offset #v -> (keyUpdateRequest_writer) x out offset #v
 
-let keyUpdate_leaf_size = keyUpdateRequest_leaf_size
+let keyUpdate_leaf_size = fun x -> (keyUpdateRequest_leaf_size) x
 
-let read_keyUpdate : PPB.copyful_parse keyUpdate_vmatch keyUpdate_parser keyUpdate_conv = read_keyUpdateRequest
+let read_keyUpdate : PPB.copyful_parse keyUpdate_vmatch keyUpdate_parser keyUpdate_conv = fun input #pm #v -> (read_keyUpdateRequest) input #pm #v
 
-let free_keyUpdate : PPB.free_t keyUpdate_vmatch = free_keyUpdateRequest
+let free_keyUpdate : PPB.free_t keyUpdate_vmatch = fun x #v -> (free_keyUpdateRequest) x #v
 
-let write_keyUpdate : PPB.l2r_safe_writer keyUpdate_vmatch keyUpdate_serializer keyUpdate_conv = write_keyUpdateRequest
+let write_keyUpdate : PPB.l2r_safe_writer keyUpdate_vmatch keyUpdate_serializer keyUpdate_conv = fun x #y out #v perr -> (write_keyUpdateRequest) x #y out #v perr
 
 let keyUpdate_bytesize_eqn x = (keyUpdateRequest_bytesize_eq (x))
 

--- a/generated/TLS13.Wire.Generated.KeyUpdateRequest.fst
+++ b/generated/TLS13.Wire.Generated.KeyUpdateRequest.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let keyUpdateRequest_repr_parser = LPI.parse_u8
 
 noextract let keyUpdateRequest_repr_serializer = LPI.serialize_u8
@@ -49,9 +47,9 @@ inline_for_extraction noextract let keyUpdateRequest_repr_reader = (PPB.leaf_rea
 
 inline_for_extraction noextract let keyUpdateRequest_repr_writer = (LPPI.l2r_leaf_write_u8 ())
 
-inline_for_extraction let synth_keyUpdateRequest (x: LP.enum_key keyUpdateRequest_enum) : Tot keyUpdateRequest = x
+inline_for_extraction noextract let synth_keyUpdateRequest (x: LP.enum_key keyUpdateRequest_enum) : Tot keyUpdateRequest = x
 
-inline_for_extraction let synth_keyUpdateRequest_inv (x: keyUpdateRequest) : Tot (LP.enum_key keyUpdateRequest_enum) =
+inline_for_extraction noextract let synth_keyUpdateRequest_inv (x: keyUpdateRequest) : Tot (LP.enum_key keyUpdateRequest_enum) =
   [@inline_let] let _ : squash (LP.list_mem x (LP.list_map fst keyUpdateRequest_enum)) =
     _ by (LP.synth_maybe_enum_key_inv_unknown_tac x)
   in

--- a/generated/TLS13.Wire.Generated.NameType.fst
+++ b/generated/TLS13.Wire.Generated.NameType.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let nameType_repr_parser = LPI.parse_u8
 
 noextract let nameType_repr_serializer = LPI.serialize_u8
@@ -49,9 +47,9 @@ inline_for_extraction noextract let nameType_repr_reader = (PPB.leaf_reader_of_s
 
 inline_for_extraction noextract let nameType_repr_writer = (LPPI.l2r_leaf_write_u8 ())
 
-inline_for_extraction let synth_nameType (x: LP.enum_key nameType_enum) : Tot nameType = x
+inline_for_extraction noextract let synth_nameType (x: LP.enum_key nameType_enum) : Tot nameType = x
 
-inline_for_extraction let synth_nameType_inv (x: nameType) : Tot (LP.enum_key nameType_enum) =
+inline_for_extraction noextract let synth_nameType_inv (x: nameType) : Tot (LP.enum_key nameType_enum) =
   [@inline_let] let _ : squash (LP.list_mem x (LP.list_map fst nameType_enum)) =
     _ by (LP.synth_maybe_enum_key_inv_unknown_tac x)
   in

--- a/generated/TLS13.Wire.Generated.NamedGroup.fst
+++ b/generated/TLS13.Wire.Generated.NamedGroup.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let namedGroup_repr_parser = LPI.parse_u16
 
 noextract let namedGroup_repr_serializer = LPI.serialize_u16
@@ -49,7 +47,7 @@ inline_for_extraction noextract let namedGroup_repr_reader = (PPB.leaf_reader_of
 
 inline_for_extraction noextract let namedGroup_repr_writer = (LPPI.l2r_leaf_write_u16 ())
 
-inline_for_extraction let synth_namedGroup (x:LP.maybe_enum_key namedGroup_enum) : namedGroup = 
+inline_for_extraction noextract let synth_namedGroup (x:LP.maybe_enum_key namedGroup_enum) : namedGroup = 
   match x with
   | LP.Known k -> k
   | LP.Unknown y ->
@@ -57,7 +55,7 @@ inline_for_extraction let synth_namedGroup (x:LP.maybe_enum_key namedGroup_enum)
     [@inline_let] let _ = assert_norm (LP.list_mem v (LP.list_map snd namedGroup_enum) == known_namedGroup_repr v) in
     Unknown_namedGroup v
 
-inline_for_extraction let synth_namedGroup_inv (x:namedGroup) : LP.maybe_enum_key namedGroup_enum = 
+inline_for_extraction noextract let synth_namedGroup_inv (x:namedGroup) : LP.maybe_enum_key namedGroup_enum = 
   match x with
   | Unknown_namedGroup y ->
     [@inline_let] let v : U16.t = y in

--- a/generated/TLS13.Wire.Generated.NamedGroupList.fst
+++ b/generated/TLS13.Wire.Generated.NamedGroupList.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 private let pre : squash (LP.vldata_vlarray_precond 2 65535 namedGroup_parser 1 32767 == true) = _ by (FStar.Tactics.trefl ())
 
 let namedGroupList_parser =
@@ -48,10 +46,10 @@ let namedGroupList_serializer =
 let namedGroupList_bytesize_eq x = ()
 
 let namedGroupList_validator =
- PPAR.validate_vlarray 2 65535 namedGroup_serializer namedGroup_validator 1 32767 () (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+ PPAR.validate_vlarray 2 65535 namedGroup_serializer namedGroup_validator 1 32767 () (PPBI.leaf_read_bounded_integer_2 ()) ()
 
 let namedGroupList_jumper =
- PPAR.jump_vlarray 2 65535 namedGroup_serializer 1 32767 () (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+ PPAR.jump_vlarray 2 65535 namedGroup_serializer 1 32767 () (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ())) ()
 
 let namedGroupList_bytesize_eqn x = LP.length_serialize_vlarray 2 65535 namedGroup_serializer 1 32767 () x
 
@@ -63,7 +61,7 @@ let read_namedGroupList : PPB.copyful_parse namedGroupList_vmatch namedGroupList
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 2 65535 (LP.serialize_list _ namedGroup_serializer)
        (PPLS.copyful_parse_list read_namedGroup namedGroup_jumper ())
-       (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_2 ()))
     (LP.vldata_to_vlarray 2 65535 namedGroup_serializer 1 32767 ())
     (LP.vlarray_to_vldata 2 65535 namedGroup_serializer 1 32767 ())
 
@@ -76,8 +74,8 @@ let write_namedGroupList : PPB.l2r_safe_writer namedGroupList_vmatch namedGroupL
   assert_norm ((LP.get_parser_kind namedGroup_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind namedGroup_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 2 (LSeqB.mk_seq_sizet 2 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz (LP.serialize_list _ namedGroup_serializer)
-       (PPLS.l2r_safe_writer_list namedGroup_serializer write_namedGroup ()) fits_u64_squash) <: PPB.l2r_safe_writer _ (LP.serialize_bounded_vldata_strong 2 65535 (LP.serialize_list _ namedGroup_serializer)) _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 2 2ul 65535 65535ul 2 2sz (LP.serialize_list _ namedGroup_serializer)
+       (PPLS.l2r_safe_writer_list namedGroup_serializer write_namedGroup ())) <: PPB.l2r_safe_writer _ (LP.serialize_bounded_vldata_strong 2 65535 (LP.serialize_list _ namedGroup_serializer)) _)
     (LP.vldata_to_vlarray 2 65535 namedGroup_serializer 1 32767 ())
     (LP.vlarray_to_vldata 2 65535 namedGroup_serializer 1 32767 ())
 

--- a/generated/TLS13.Wire.Generated.ProtocolName.fst
+++ b/generated/TLS13.Wire.Generated.ProtocolName.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let protocolName_parser = LP.parse_bounded_seq_vlbytes 1 255
 
 noextract let protocolName_serializer = LP.serialize_bounded_seq_vlbytes 1 255
 
 let protocolName_bytesize_eq x = ()
 
-let protocolName_validator = LSeqB.validate_bounded_seq_vlbytes 1 255 (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+let protocolName_validator = LSeqB.validate_bounded_seq_vlbytes 1 255 (PPBI.leaf_read_bounded_integer_1 ())
 
-let protocolName_jumper = LSeqB.jump_bounded_seq_vlbytes 1 255 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 255)) (PPBI.leaf_read_bounded_integer_1 fits_u64_squash)) fits_u64_squash
+let protocolName_jumper = LSeqB.jump_bounded_seq_vlbytes 1 255 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 255)) (PPBI.leaf_read_bounded_integer_1 ()))
 
-let read_protocolName = LSeqB.copyful_parse_bounded_seq_vlbytes 1 255 (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+let read_protocolName = LSeqB.copyful_parse_bounded_seq_vlbytes 1 255 (PPBI.leaf_read_bounded_integer_1 ())
 
 let free_protocolName : PPB.free_t protocolName_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_protocolName = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 255 (LSeqB.mk_seq_sizet 255 fits_u64_squash) 1sz fits_u64_squash
+let write_protocolName = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 1ul 255 255ul 1sz
 
-let size_protocolName = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 255 (LSeqB.mk_seq_sizet 255 fits_u64_squash) 1sz fits_u64_squash
+let size_protocolName = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 1ul 255 255ul 1sz
 
 let protocolName_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 1 255 x
 

--- a/generated/TLS13.Wire.Generated.ProtocolNameList.fst
+++ b/generated/TLS13.Wire.Generated.ProtocolNameList.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let protocolNameList_list_bytesize_nil = LP.serialize_list_nil protocolName_parser protocolName_serializer
 
 let protocolNameList_list_bytesize_cons x y = LP.serialize_list_cons protocolName_parser protocolName_serializer x y; (protocolName_bytesize_eq (x))
@@ -54,12 +52,12 @@ let protocolNameList_serializer = LP.serialize_synth _ synth_protocolNameList pr
 let protocolNameList_bytesize_eq x = ()
 
 inline_for_extraction let protocolNameList'_validator : LPS.validator protocolNameList'_parser =
-  PPVD.validate_bounded_vldata_strong 2 65535 (LP.serialize_list _ protocolName_serializer) (PPLS.validate_list protocolName_validator ()) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 2 65535 (LP.serialize_list _ protocolName_serializer) (PPLS.validate_list protocolName_validator ()) (PPBI.leaf_read_bounded_integer_2 ())
 
 let protocolNameList_validator = LPC.validate_synth protocolNameList'_validator synth_protocolNameList
 
 inline_for_extraction let protocolNameList'_jumper : LPS.jumper protocolNameList'_parser =
-  PPVD.jump_bounded_vldata_strong 2 65535 (LP.serialize_list _ protocolName_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 2 65535 (LP.serialize_list _ protocolName_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let protocolNameList_jumper = LPC.jump_synth protocolNameList'_jumper synth_protocolNameList
 
@@ -76,7 +74,7 @@ let read_protocolNameList : PPB.copyful_parse protocolNameList_vmatch protocolNa
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 2 65535 (LP.serialize_list _ protocolName_serializer)
        (PPLS.copyful_parse_list read_protocolName protocolName_jumper ())
-       (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_2 ()))
     synth_protocolNameList synth_protocolNameList_recip
 
 let free_protocolNameList : PPB.free_t protocolNameList_vmatch =
@@ -88,7 +86,7 @@ let write_protocolNameList : PPB.l2r_safe_writer protocolNameList_vmatch protoco
   assert_norm ((LP.get_parser_kind protocolName_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind protocolName_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 2 (LSeqB.mk_seq_sizet 2 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz (LP.serialize_list _ protocolName_serializer)
-       (PPLS.l2r_safe_writer_list protocolName_serializer write_protocolName ()) fits_u64_squash) <: PPB.l2r_safe_writer _ protocolNameList'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 2 2ul 65535 65535ul 2 2sz (LP.serialize_list _ protocolName_serializer)
+       (PPLS.l2r_safe_writer_list protocolName_serializer write_protocolName ())) <: PPB.l2r_safe_writer _ protocolNameList'_serializer _)
     synth_protocolNameList synth_protocolNameList_recip
 

--- a/generated/TLS13.Wire.Generated.ProtocolVersion.fst
+++ b/generated/TLS13.Wire.Generated.ProtocolVersion.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let protocolVersion_repr_parser = LPI.parse_u16
 
 noextract let protocolVersion_repr_serializer = LPI.serialize_u16
@@ -49,9 +47,9 @@ inline_for_extraction noextract let protocolVersion_repr_reader = (PPB.leaf_read
 
 inline_for_extraction noextract let protocolVersion_repr_writer = (LPPI.l2r_leaf_write_u16 ())
 
-inline_for_extraction let synth_protocolVersion (x: LP.enum_key protocolVersion_enum) : Tot protocolVersion = x
+inline_for_extraction noextract let synth_protocolVersion (x: LP.enum_key protocolVersion_enum) : Tot protocolVersion = x
 
-inline_for_extraction let synth_protocolVersion_inv (x: protocolVersion) : Tot (LP.enum_key protocolVersion_enum) =
+inline_for_extraction noextract let synth_protocolVersion_inv (x: protocolVersion) : Tot (LP.enum_key protocolVersion_enum) =
   [@inline_let] let _ : squash (LP.list_mem x (LP.list_map fst protocolVersion_enum)) =
     _ by (LP.synth_maybe_enum_key_inv_unknown_tac x)
   in

--- a/generated/TLS13.Wire.Generated.Random.fst
+++ b/generated/TLS13.Wire.Generated.Random.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let random_parser = LP.parse_lseq_bytes 32
 
 noextract let random_serializer = LP.serialize_lseq_bytes 32

--- a/generated/TLS13.Wire.Generated.ServerHello.fst
+++ b/generated/TLS13.Wire.Generated.ServerHello.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 open TLS13.Wire.Generated.ServerHello_body
 
 let synth_serverHello_recip_inverse () : Lemma (LP.synth_inverse synth_serverHello_recip synth_serverHello) = ()
@@ -90,7 +88,7 @@ let read_serverHello : PPB.copyful_parse serverHello_vmatch serverHello_parser s
   assert_norm (serverHello_parser_kind == serverHello'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair protocolVersion_jumper read_protocolVersion () read_serverHello_body) synth_serverHello synth_serverHello_recip
 
-let free_serverHello : PPB.free_t serverHello_vmatch = (PPC.free_pair free_protocolVersion free_serverHello_body)
+let free_serverHello : PPB.free_t serverHello_vmatch = fun x #v -> ((PPC.free_pair free_protocolVersion free_serverHello_body)) x #v
 
 let write_serverHello : PPB.l2r_safe_writer serverHello_vmatch serverHello_serializer serverHello_conv =
   synth_serverHello_injective ();

--- a/generated/TLS13.Wire.Generated.ServerHelloBody.fst
+++ b/generated/TLS13.Wire.Generated.ServerHelloBody.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 (* Type of field legacy_session_id_echo*)
 open TLS13.Wire.Generated.ServerHelloBody_legacy_session_id_echo
 
@@ -94,7 +92,7 @@ let read_serverHelloBody : PPB.copyful_parse serverHelloBody_vmatch serverHelloB
   assert_norm (serverHelloBody_parser_kind == serverHelloBody'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair (LPC.jump_nondep_then serverHelloBody_legacy_session_id_echo_jumper cipherSuite_jumper) (PPC.copyful_parse_pair serverHelloBody_legacy_session_id_echo_jumper read_serverHelloBody_legacy_session_id_echo () read_cipherSuite) () (PPC.copyful_parse_pair LPPI.jump_u8 (PPB.copyful_parse_leaf (PPB.leaf_reader_of_serialized (LPPI.read_u8' ()))) () read_serverHelloBody_extensions)) synth_serverHelloBody synth_serverHelloBody_recip
 
-let free_serverHelloBody : PPB.free_t serverHelloBody_vmatch = (PPC.free_pair (PPC.free_pair free_serverHelloBody_legacy_session_id_echo free_cipherSuite) (PPC.free_pair (PPB.free_leaf #U8.t) free_serverHelloBody_extensions))
+let free_serverHelloBody : PPB.free_t serverHelloBody_vmatch = fun x #v -> ((PPC.free_pair (PPC.free_pair free_serverHelloBody_legacy_session_id_echo free_cipherSuite) (PPC.free_pair (PPB.free_leaf #U8.t) free_serverHelloBody_extensions))) x #v
 
 let write_serverHelloBody : PPB.l2r_safe_writer serverHelloBody_vmatch serverHelloBody_serializer serverHelloBody_conv =
   synth_serverHelloBody_injective ();

--- a/generated/TLS13.Wire.Generated.ServerHelloBody_extensions.fst
+++ b/generated/TLS13.Wire.Generated.ServerHelloBody_extensions.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let serverHelloBody_extensions_list_bytesize_nil = LP.serialize_list_nil extensionServerHello_parser extensionServerHello_serializer
 
 let serverHelloBody_extensions_list_bytesize_cons x y = LP.serialize_list_cons extensionServerHello_parser extensionServerHello_serializer x y; (extensionServerHello_bytesize_eq (x))
@@ -54,12 +52,12 @@ let serverHelloBody_extensions_serializer = LP.serialize_synth _ synth_serverHel
 let serverHelloBody_extensions_bytesize_eq x = ()
 
 inline_for_extraction let serverHelloBody_extensions'_validator : LPS.validator serverHelloBody_extensions'_parser =
-  PPVD.validate_bounded_vldata_strong 6 65535 (LP.serialize_list _ extensionServerHello_serializer) (PPLS.validate_list extensionServerHello_validator ()) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 6 65535 (LP.serialize_list _ extensionServerHello_serializer) (PPLS.validate_list extensionServerHello_validator ()) (PPBI.leaf_read_bounded_integer_2 ())
 
 let serverHelloBody_extensions_validator = LPC.validate_synth serverHelloBody_extensions'_validator synth_serverHelloBody_extensions
 
 inline_for_extraction let serverHelloBody_extensions'_jumper : LPS.jumper serverHelloBody_extensions'_parser =
-  PPVD.jump_bounded_vldata_strong 6 65535 (LP.serialize_list _ extensionServerHello_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 6 65535 (LP.serialize_list _ extensionServerHello_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let serverHelloBody_extensions_jumper = LPC.jump_synth serverHelloBody_extensions'_jumper synth_serverHelloBody_extensions
 
@@ -76,7 +74,7 @@ let read_serverHelloBody_extensions : PPB.copyful_parse serverHelloBody_extensio
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 6 65535 (LP.serialize_list _ extensionServerHello_serializer)
        (PPLS.copyful_parse_list read_extensionServerHello extensionServerHello_jumper ())
-       (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_2 ()))
     synth_serverHelloBody_extensions synth_serverHelloBody_extensions_recip
 
 let free_serverHelloBody_extensions : PPB.free_t serverHelloBody_extensions_vmatch =
@@ -88,7 +86,7 @@ let write_serverHelloBody_extensions : PPB.l2r_safe_writer serverHelloBody_exten
   assert_norm ((LP.get_parser_kind extensionServerHello_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind extensionServerHello_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 6 (LSeqB.mk_seq_sizet 6 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz (LP.serialize_list _ extensionServerHello_serializer)
-       (PPLS.l2r_safe_writer_list extensionServerHello_serializer write_extensionServerHello ()) fits_u64_squash) <: PPB.l2r_safe_writer _ serverHelloBody_extensions'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 6 6ul 65535 65535ul 2 2sz (LP.serialize_list _ extensionServerHello_serializer)
+       (PPLS.l2r_safe_writer_list extensionServerHello_serializer write_extensionServerHello ())) <: PPB.l2r_safe_writer _ serverHelloBody_extensions'_serializer _)
     synth_serverHelloBody_extensions synth_serverHelloBody_extensions_recip
 

--- a/generated/TLS13.Wire.Generated.ServerHelloBody_legacy_session_id_echo.fst
+++ b/generated/TLS13.Wire.Generated.ServerHelloBody_legacy_session_id_echo.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let serverHelloBody_legacy_session_id_echo_parser = LP.parse_bounded_seq_vlbytes 0 32
 
 noextract let serverHelloBody_legacy_session_id_echo_serializer = LP.serialize_bounded_seq_vlbytes 0 32
 
 let serverHelloBody_legacy_session_id_echo_bytesize_eq x = ()
 
-let serverHelloBody_legacy_session_id_echo_validator = LSeqB.validate_bounded_seq_vlbytes 0 32 (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+let serverHelloBody_legacy_session_id_echo_validator = LSeqB.validate_bounded_seq_vlbytes 0 32 (PPBI.leaf_read_bounded_integer_1 ())
 
-let serverHelloBody_legacy_session_id_echo_jumper = LSeqB.jump_bounded_seq_vlbytes 0 32 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 32)) (PPBI.leaf_read_bounded_integer_1 fits_u64_squash)) fits_u64_squash
+let serverHelloBody_legacy_session_id_echo_jumper = LSeqB.jump_bounded_seq_vlbytes 0 32 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 32)) (PPBI.leaf_read_bounded_integer_1 ()))
 
-let read_serverHelloBody_legacy_session_id_echo = LSeqB.copyful_parse_bounded_seq_vlbytes 0 32 (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+let read_serverHelloBody_legacy_session_id_echo = LSeqB.copyful_parse_bounded_seq_vlbytes 0 32 (PPBI.leaf_read_bounded_integer_1 ())
 
 let free_serverHelloBody_legacy_session_id_echo : PPB.free_t serverHelloBody_legacy_session_id_echo_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_serverHelloBody_legacy_session_id_echo = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 32 (LSeqB.mk_seq_sizet 32 fits_u64_squash) 1sz fits_u64_squash
+let write_serverHelloBody_legacy_session_id_echo = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 32 32ul 1sz
 
-let size_serverHelloBody_legacy_session_id_echo = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 32 (LSeqB.mk_seq_sizet 32 fits_u64_squash) 1sz fits_u64_squash
+let size_serverHelloBody_legacy_session_id_echo = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 32 32ul 1sz
 
 let serverHelloBody_legacy_session_id_echo_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 32 x
 

--- a/generated/TLS13.Wire.Generated.ServerHello_body.fst
+++ b/generated/TLS13.Wire.Generated.ServerHello_body.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let serverHello_body_random_parser = LP.parse_lseq_bytes 32
 
 noextract let serverHello_body_random_serializer = LP.serialize_lseq_bytes 32
@@ -61,7 +59,7 @@ let serverHello_body_parser = LP.parse_ifthenelse parse_serverHello_body_param
 inline_for_extraction let serialize_serverHello_body_payload (b:bool) : Tot (LP.serializer (dsnd (parse_serverHello_body_param.LP.parse_ifthenelse_payload_parser b))) =
   if b then serverHelloBody_serializer else serverHelloBody_serializer
 
-inline_for_extraction let serverHello_body_synth_recip (x:serverHello_body) : GTot (t:serverHello_body_random & (serverHello_body_payload (serverHello_body_cond t))) =
+inline_for_extraction noextract let serverHello_body_synth_recip (x:serverHello_body) : GTot (t:serverHello_body_random & (serverHello_body_payload (serverHello_body_cond t))) =
   match x with
   | HelloRetryRequest y -> (| serverHello_body_cst, y |)
   | ServerHello_body_false m -> (| m.tag, m.value |)

--- a/generated/TLS13.Wire.Generated.ServerName.fst
+++ b/generated/TLS13.Wire.Generated.ServerName.fst
@@ -37,8 +37,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 // Need high Z3 limits for large sum types
 #set-options "--z3rlimit 60"
 
@@ -83,7 +81,7 @@ noextract inline_for_extraction let synth_serverName_cases_recip (k:LP.enum_key 
   | Host_name -> [@inline_let] let _ = synth_serverName_cases_recip_pre_intro Host_name x in
     (match x with Name_host_name y -> (from_serverName_case_of_nameType Host_name y))
 
-inline_for_extraction let serverName_sum = LP.make_sum' nameType_enum key_of_serverName
+inline_for_extraction noextract let serverName_sum = LP.make_sum' nameType_enum key_of_serverName
   serverName_case_of_nameType synth_serverName_cases synth_serverName_cases_recip
   (_ by (LP.make_sum_synth_case_recip_synth_case_tac ()))
   (_ by (LP.synth_case_synth_case_recip_tac ()))

--- a/generated/TLS13.Wire.Generated.ServerNameList.fst
+++ b/generated/TLS13.Wire.Generated.ServerNameList.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 let serverNameList_list_bytesize_nil = LP.serialize_list_nil serverName_parser serverName_serializer
 
 let serverNameList_list_bytesize_cons x y = LP.serialize_list_cons serverName_parser serverName_serializer x y; (serverName_bytesize_eq (x))
@@ -54,12 +52,12 @@ let serverNameList_serializer = LP.serialize_synth _ synth_serverNameList server
 let serverNameList_bytesize_eq x = ()
 
 inline_for_extraction let serverNameList'_validator : LPS.validator serverNameList'_parser =
-  PPVD.validate_bounded_vldata_strong 1 65535 (LP.serialize_list _ serverName_serializer) (PPLS.validate_list serverName_validator ()) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+  PPVD.validate_bounded_vldata_strong 1 65535 (LP.serialize_list _ serverName_serializer) (PPLS.validate_list serverName_validator ()) (PPBI.leaf_read_bounded_integer_2 ())
 
 let serverNameList_validator = LPC.validate_synth serverNameList'_validator synth_serverNameList
 
 inline_for_extraction let serverNameList'_jumper : LPS.jumper serverNameList'_parser =
-  PPVD.jump_bounded_vldata_strong 1 65535 (LP.serialize_list _ serverName_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+  PPVD.jump_bounded_vldata_strong 1 65535 (LP.serialize_list _ serverName_serializer) (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
 let serverNameList_jumper = LPC.jump_synth serverNameList'_jumper synth_serverNameList
 
@@ -76,7 +74,7 @@ let read_serverNameList : PPB.copyful_parse serverNameList_vmatch serverNameList
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 1 65535 (LP.serialize_list _ serverName_serializer)
        (PPLS.copyful_parse_list read_serverName serverName_jumper ())
-       (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_2 ()))
     synth_serverNameList synth_serverNameList_recip
 
 let free_serverNameList : PPB.free_t serverNameList_vmatch =
@@ -88,7 +86,7 @@ let write_serverNameList : PPB.l2r_safe_writer serverNameList_vmatch serverNameL
   assert_norm ((LP.get_parser_kind serverName_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind serverName_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2 2sz (LP.serialize_list _ serverName_serializer)
-       (PPLS.l2r_safe_writer_list serverName_serializer write_serverName ()) fits_u64_squash) <: PPB.l2r_safe_writer _ serverNameList'_serializer _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 1 1ul 65535 65535ul 2 2sz (LP.serialize_list _ serverName_serializer)
+       (PPLS.l2r_safe_writer_list serverName_serializer write_serverName ())) <: PPB.l2r_safe_writer _ serverNameList'_serializer _)
     synth_serverNameList synth_serverNameList_recip
 

--- a/generated/TLS13.Wire.Generated.SignatureScheme.fst
+++ b/generated/TLS13.Wire.Generated.SignatureScheme.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let signatureScheme_repr_parser = LPI.parse_u16
 
 noextract let signatureScheme_repr_serializer = LPI.serialize_u16
@@ -49,7 +47,7 @@ inline_for_extraction noextract let signatureScheme_repr_reader = (PPB.leaf_read
 
 inline_for_extraction noextract let signatureScheme_repr_writer = (LPPI.l2r_leaf_write_u16 ())
 
-inline_for_extraction let synth_signatureScheme (x:LP.maybe_enum_key signatureScheme_enum) : signatureScheme = 
+inline_for_extraction noextract let synth_signatureScheme (x:LP.maybe_enum_key signatureScheme_enum) : signatureScheme = 
   match x with
   | LP.Known k -> k
   | LP.Unknown y ->
@@ -57,7 +55,7 @@ inline_for_extraction let synth_signatureScheme (x:LP.maybe_enum_key signatureSc
     [@inline_let] let _ = assert_norm (LP.list_mem v (LP.list_map snd signatureScheme_enum) == known_signatureScheme_repr v) in
     Unknown_signatureScheme v
 
-inline_for_extraction let synth_signatureScheme_inv (x:signatureScheme) : LP.maybe_enum_key signatureScheme_enum = 
+inline_for_extraction noextract let synth_signatureScheme_inv (x:signatureScheme) : LP.maybe_enum_key signatureScheme_enum = 
   match x with
   | Unknown_signatureScheme y ->
     [@inline_let] let v : U16.t = y in

--- a/generated/TLS13.Wire.Generated.SignatureSchemeList.fst
+++ b/generated/TLS13.Wire.Generated.SignatureSchemeList.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 private let pre : squash (LP.vldata_vlarray_precond 2 65534 signatureScheme_parser 1 32767 == true) = _ by (FStar.Tactics.trefl ())
 
 let signatureSchemeList_parser =
@@ -48,10 +46,10 @@ let signatureSchemeList_serializer =
 let signatureSchemeList_bytesize_eq x = ()
 
 let signatureSchemeList_validator =
- PPAR.validate_vlarray 2 65534 signatureScheme_serializer signatureScheme_validator 1 32767 () (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+ PPAR.validate_vlarray 2 65534 signatureScheme_serializer signatureScheme_validator 1 32767 () (PPBI.leaf_read_bounded_integer_2 ()) ()
 
 let signatureSchemeList_jumper =
- PPAR.jump_vlarray 2 65534 signatureScheme_serializer 1 32767 () (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65534)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+ PPAR.jump_vlarray 2 65534 signatureScheme_serializer 1 32767 () (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65534)) (PPBI.leaf_read_bounded_integer_2 ())) ()
 
 let signatureSchemeList_bytesize_eqn x = LP.length_serialize_vlarray 2 65534 signatureScheme_serializer 1 32767 () x
 
@@ -63,7 +61,7 @@ let read_signatureSchemeList : PPB.copyful_parse signatureSchemeList_vmatch sign
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 2 65534 (LP.serialize_list _ signatureScheme_serializer)
        (PPLS.copyful_parse_list read_signatureScheme signatureScheme_jumper ())
-       (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_2 ()))
     (LP.vldata_to_vlarray 2 65534 signatureScheme_serializer 1 32767 ())
     (LP.vlarray_to_vldata 2 65534 signatureScheme_serializer 1 32767 ())
 
@@ -76,8 +74,8 @@ let write_signatureSchemeList : PPB.l2r_safe_writer signatureSchemeList_vmatch s
   assert_norm ((LP.get_parser_kind signatureScheme_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind signatureScheme_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 2 (LSeqB.mk_seq_sizet 2 fits_u64_squash) 65534 (LSeqB.mk_seq_sizet 65534 fits_u64_squash) 2 2sz (LP.serialize_list _ signatureScheme_serializer)
-       (PPLS.l2r_safe_writer_list signatureScheme_serializer write_signatureScheme ()) fits_u64_squash) <: PPB.l2r_safe_writer _ (LP.serialize_bounded_vldata_strong 2 65534 (LP.serialize_list _ signatureScheme_serializer)) _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 2 2ul 65534 65534ul 2 2sz (LP.serialize_list _ signatureScheme_serializer)
+       (PPLS.l2r_safe_writer_list signatureScheme_serializer write_signatureScheme ())) <: PPB.l2r_safe_writer _ (LP.serialize_bounded_vldata_strong 2 65534 (LP.serialize_list _ signatureScheme_serializer)) _)
     (LP.vldata_to_vlarray 2 65534 signatureScheme_serializer 1 32767 ())
     (LP.vlarray_to_vldata 2 65534 signatureScheme_serializer 1 32767 ())
 

--- a/generated/TLS13.Wire.Generated.SupportedVersionsClientHello.fst
+++ b/generated/TLS13.Wire.Generated.SupportedVersionsClientHello.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 private let pre : squash (LP.vldata_vlarray_precond 2 254 protocolVersion_parser 1 127 == true) = _ by (FStar.Tactics.trefl ())
 
 let supportedVersionsClientHello_parser =
@@ -48,10 +46,10 @@ let supportedVersionsClientHello_serializer =
 let supportedVersionsClientHello_bytesize_eq x = ()
 
 let supportedVersionsClientHello_validator =
- PPAR.validate_vlarray 2 254 protocolVersion_serializer protocolVersion_validator 1 127 () (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash
+ PPAR.validate_vlarray 2 254 protocolVersion_serializer protocolVersion_validator 1 127 () (PPBI.leaf_read_bounded_integer_1 ()) ()
 
 let supportedVersionsClientHello_jumper =
- PPAR.jump_vlarray 2 254 protocolVersion_serializer 1 127 () (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 254)) (PPBI.leaf_read_bounded_integer_1 fits_u64_squash)) fits_u64_squash
+ PPAR.jump_vlarray 2 254 protocolVersion_serializer 1 127 () (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 254)) (PPBI.leaf_read_bounded_integer_1 ())) ()
 
 let supportedVersionsClientHello_bytesize_eqn x = LP.length_serialize_vlarray 2 254 protocolVersion_serializer 1 127 () x
 
@@ -63,7 +61,7 @@ let read_supportedVersionsClientHello : PPB.copyful_parse supportedVersionsClien
   PPC.copyful_parse_synth
     (PPVD.copyful_parse_bounded_vldata_strong_payload 2 254 (LP.serialize_list _ protocolVersion_serializer)
        (PPLS.copyful_parse_list read_protocolVersion protocolVersion_jumper ())
-       (PPBI.leaf_read_bounded_integer_1 fits_u64_squash) fits_u64_squash)
+       (PPBI.leaf_read_bounded_integer_1 ()))
     (LP.vldata_to_vlarray 2 254 protocolVersion_serializer 1 127 ())
     (LP.vlarray_to_vldata 2 254 protocolVersion_serializer 1 127 ())
 
@@ -76,8 +74,8 @@ let write_supportedVersionsClientHello : PPB.l2r_safe_writer supportedVersionsCl
   assert_norm ((LP.get_parser_kind protocolVersion_parser).LP.parser_kind_subkind == Some LP.ParserStrong);
   assert_norm ((LP.get_parser_kind protocolVersion_parser).LP.parser_kind_low > 0);
   PPC.l2r_safe_writer_synth
-    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 2 (LSeqB.mk_seq_sizet 2 fits_u64_squash) 254 (LSeqB.mk_seq_sizet 254 fits_u64_squash) 1 1sz (LP.serialize_list _ protocolVersion_serializer)
-       (PPLS.l2r_safe_writer_list protocolVersion_serializer write_protocolVersion ()) fits_u64_squash) <: PPB.l2r_safe_writer _ (LP.serialize_bounded_vldata_strong 2 254 (LP.serialize_list _ protocolVersion_serializer)) _)
+    ((PPVD.l2r_safe_writer_bounded_vldata_strong_payload 2 2ul 254 254ul 1 1sz (LP.serialize_list _ protocolVersion_serializer)
+       (PPLS.l2r_safe_writer_list protocolVersion_serializer write_protocolVersion ())) <: PPB.l2r_safe_writer _ (LP.serialize_bounded_vldata_strong 2 254 (LP.serialize_list _ protocolVersion_serializer)) _)
     (LP.vldata_to_vlarray 2 254 protocolVersion_serializer 1 127 ())
     (LP.vlarray_to_vldata 2 254 protocolVersion_serializer 1 127 ())
 

--- a/generated/TLS13.Wire.Generated.SupportedVersionsServerHello.fst
+++ b/generated/TLS13.Wire.Generated.SupportedVersionsServerHello.fst
@@ -35,27 +35,25 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let supportedVersionsServerHello_parser = protocolVersion_parser
 
 noextract let supportedVersionsServerHello_serializer = protocolVersion_serializer
 
 let supportedVersionsServerHello_bytesize_eq x = ()
 
-let supportedVersionsServerHello_validator = protocolVersion_validator
+let supportedVersionsServerHello_validator = fun input poffset #offset #pm #v -> (protocolVersion_validator) input poffset #offset #pm #v
 
-let supportedVersionsServerHello_reader = protocolVersion_reader
+let supportedVersionsServerHello_reader = fun input #pm #v -> (protocolVersion_reader) input #pm #v
 
-let supportedVersionsServerHello_writer = protocolVersion_writer
+let supportedVersionsServerHello_writer = fun x out offset #v -> (protocolVersion_writer) x out offset #v
 
-let supportedVersionsServerHello_leaf_size = protocolVersion_leaf_size
+let supportedVersionsServerHello_leaf_size = fun x -> (protocolVersion_leaf_size) x
 
-let read_supportedVersionsServerHello : PPB.copyful_parse supportedVersionsServerHello_vmatch supportedVersionsServerHello_parser supportedVersionsServerHello_conv = read_protocolVersion
+let read_supportedVersionsServerHello : PPB.copyful_parse supportedVersionsServerHello_vmatch supportedVersionsServerHello_parser supportedVersionsServerHello_conv = fun input #pm #v -> (read_protocolVersion) input #pm #v
 
-let free_supportedVersionsServerHello : PPB.free_t supportedVersionsServerHello_vmatch = free_protocolVersion
+let free_supportedVersionsServerHello : PPB.free_t supportedVersionsServerHello_vmatch = fun x #v -> (free_protocolVersion) x #v
 
-let write_supportedVersionsServerHello : PPB.l2r_safe_writer supportedVersionsServerHello_vmatch supportedVersionsServerHello_serializer supportedVersionsServerHello_conv = write_protocolVersion
+let write_supportedVersionsServerHello : PPB.l2r_safe_writer supportedVersionsServerHello_vmatch supportedVersionsServerHello_serializer supportedVersionsServerHello_conv = fun x #y out #v perr -> (write_protocolVersion) x #y out #v perr
 
 let supportedVersionsServerHello_bytesize_eqn x = (protocolVersion_bytesize_eq (x))
 

--- a/generated/TLS13.Wire.Generated.TLSCiphertext.fst
+++ b/generated/TLS13.Wire.Generated.TLSCiphertext.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 (* Type of field encrypted_record*)
 open TLS13.Wire.Generated.TLSCiphertext_encrypted_record
 
@@ -91,7 +89,7 @@ let read_tLSCiphertext : PPB.copyful_parse tLSCiphertext_vmatch tLSCiphertext_pa
   assert_norm (tLSCiphertext_parser_kind == tLSCiphertext'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair (LPC.jump_nondep_then contentType_jumper protocolVersion_jumper) (PPC.copyful_parse_pair contentType_jumper read_contentType () read_protocolVersion) () read_tLSCiphertext_encrypted_record) synth_tLSCiphertext synth_tLSCiphertext_recip
 
-let free_tLSCiphertext : PPB.free_t tLSCiphertext_vmatch = (PPC.free_pair (PPC.free_pair free_contentType free_protocolVersion) free_tLSCiphertext_encrypted_record)
+let free_tLSCiphertext : PPB.free_t tLSCiphertext_vmatch = fun x #v -> ((PPC.free_pair (PPC.free_pair free_contentType free_protocolVersion) free_tLSCiphertext_encrypted_record)) x #v
 
 let write_tLSCiphertext : PPB.l2r_safe_writer tLSCiphertext_vmatch tLSCiphertext_serializer tLSCiphertext_conv =
   synth_tLSCiphertext_injective ();
@@ -100,7 +98,7 @@ let write_tLSCiphertext : PPB.l2r_safe_writer tLSCiphertext_vmatch tLSCiphertext
 
 let size_tLSCiphertext : PPB.l2r_safe_size tLSCiphertext_vmatch tLSCiphertext_serializer tLSCiphertext_conv =
   synth_tLSCiphertext_injective ();
-  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair fits_u64_squash (PPC.l2r_safe_size_pair fits_u64_squash size_contentType () size_protocolVersion) () size_tLSCiphertext_encrypted_record) synth_tLSCiphertext synth_tLSCiphertext_recip
+  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair (PPC.l2r_safe_size_pair size_contentType () size_protocolVersion) () size_tLSCiphertext_encrypted_record) synth_tLSCiphertext synth_tLSCiphertext_recip
 
 let tLSCiphertext_bytesize_eqn x =
   [@inline_let] let _ = synth_tLSCiphertext_injective () in

--- a/generated/TLS13.Wire.Generated.TLSCiphertext_encrypted_record.fst
+++ b/generated/TLS13.Wire.Generated.TLSCiphertext_encrypted_record.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let tLSCiphertext_encrypted_record_parser = LP.parse_bounded_seq_vlbytes 0 16640
 
 noextract let tLSCiphertext_encrypted_record_serializer = LP.serialize_bounded_seq_vlbytes 0 16640
 
 let tLSCiphertext_encrypted_record_bytesize_eq x = ()
 
-let tLSCiphertext_encrypted_record_validator = LSeqB.validate_bounded_seq_vlbytes 0 16640 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let tLSCiphertext_encrypted_record_validator = LSeqB.validate_bounded_seq_vlbytes 0 16640 (PPBI.leaf_read_bounded_integer_2 ())
 
-let tLSCiphertext_encrypted_record_jumper = LSeqB.jump_bounded_seq_vlbytes 0 16640 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16640)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let tLSCiphertext_encrypted_record_jumper = LSeqB.jump_bounded_seq_vlbytes 0 16640 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16640)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_tLSCiphertext_encrypted_record = LSeqB.copyful_parse_bounded_seq_vlbytes 0 16640 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_tLSCiphertext_encrypted_record = LSeqB.copyful_parse_bounded_seq_vlbytes 0 16640 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_tLSCiphertext_encrypted_record : PPB.free_t tLSCiphertext_encrypted_record_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_tLSCiphertext_encrypted_record = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 16640 (LSeqB.mk_seq_sizet 16640 fits_u64_squash) 2sz fits_u64_squash
+let write_tLSCiphertext_encrypted_record = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 16640 16640ul 2sz
 
-let size_tLSCiphertext_encrypted_record = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 16640 (LSeqB.mk_seq_sizet 16640 fits_u64_squash) 2sz fits_u64_squash
+let size_tLSCiphertext_encrypted_record = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 16640 16640ul 2sz
 
 let tLSCiphertext_encrypted_record_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 16640 x
 

--- a/generated/TLS13.Wire.Generated.TLSPlaintext.fst
+++ b/generated/TLS13.Wire.Generated.TLSPlaintext.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 (* Type of field fragment*)
 open TLS13.Wire.Generated.TLSPlaintext_fragment
 
@@ -91,7 +89,7 @@ let read_tLSPlaintext : PPB.copyful_parse tLSPlaintext_vmatch tLSPlaintext_parse
   assert_norm (tLSPlaintext_parser_kind == tLSPlaintext'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair (LPC.jump_nondep_then contentType_jumper protocolVersion_jumper) (PPC.copyful_parse_pair contentType_jumper read_contentType () read_protocolVersion) () read_tLSPlaintext_fragment) synth_tLSPlaintext synth_tLSPlaintext_recip
 
-let free_tLSPlaintext : PPB.free_t tLSPlaintext_vmatch = (PPC.free_pair (PPC.free_pair free_contentType free_protocolVersion) free_tLSPlaintext_fragment)
+let free_tLSPlaintext : PPB.free_t tLSPlaintext_vmatch = fun x #v -> ((PPC.free_pair (PPC.free_pair free_contentType free_protocolVersion) free_tLSPlaintext_fragment)) x #v
 
 let write_tLSPlaintext : PPB.l2r_safe_writer tLSPlaintext_vmatch tLSPlaintext_serializer tLSPlaintext_conv =
   synth_tLSPlaintext_injective ();
@@ -100,7 +98,7 @@ let write_tLSPlaintext : PPB.l2r_safe_writer tLSPlaintext_vmatch tLSPlaintext_se
 
 let size_tLSPlaintext : PPB.l2r_safe_size tLSPlaintext_vmatch tLSPlaintext_serializer tLSPlaintext_conv =
   synth_tLSPlaintext_injective ();
-  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair fits_u64_squash (PPC.l2r_safe_size_pair fits_u64_squash size_contentType () size_protocolVersion) () size_tLSPlaintext_fragment) synth_tLSPlaintext synth_tLSPlaintext_recip
+  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair (PPC.l2r_safe_size_pair size_contentType () size_protocolVersion) () size_tLSPlaintext_fragment) synth_tLSPlaintext synth_tLSPlaintext_recip
 
 let tLSPlaintext_bytesize_eqn x =
   [@inline_let] let _ = synth_tLSPlaintext_injective () in

--- a/generated/TLS13.Wire.Generated.TLSPlaintext_fragment.fst
+++ b/generated/TLS13.Wire.Generated.TLSPlaintext_fragment.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let tLSPlaintext_fragment_parser = LP.parse_bounded_seq_vlbytes 0 16640
 
 noextract let tLSPlaintext_fragment_serializer = LP.serialize_bounded_seq_vlbytes 0 16640
 
 let tLSPlaintext_fragment_bytesize_eq x = ()
 
-let tLSPlaintext_fragment_validator = LSeqB.validate_bounded_seq_vlbytes 0 16640 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let tLSPlaintext_fragment_validator = LSeqB.validate_bounded_seq_vlbytes 0 16640 (PPBI.leaf_read_bounded_integer_2 ())
 
-let tLSPlaintext_fragment_jumper = LSeqB.jump_bounded_seq_vlbytes 0 16640 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16640)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let tLSPlaintext_fragment_jumper = LSeqB.jump_bounded_seq_vlbytes 0 16640 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 16640)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_tLSPlaintext_fragment = LSeqB.copyful_parse_bounded_seq_vlbytes 0 16640 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_tLSPlaintext_fragment = LSeqB.copyful_parse_bounded_seq_vlbytes 0 16640 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_tLSPlaintext_fragment : PPB.free_t tLSPlaintext_fragment_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_tLSPlaintext_fragment = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 16640 (LSeqB.mk_seq_sizet 16640 fits_u64_squash) 2sz fits_u64_squash
+let write_tLSPlaintext_fragment = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 16640 16640ul 2sz
 
-let size_tLSPlaintext_fragment = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 16640 (LSeqB.mk_seq_sizet 16640 fits_u64_squash) 2sz fits_u64_squash
+let size_tLSPlaintext_fragment = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 16640 16640ul 2sz
 
 let tLSPlaintext_fragment_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 16640 x
 

--- a/generated/TLS13.Wire.Generated.UnknownExtension.fst
+++ b/generated/TLS13.Wire.Generated.UnknownExtension.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let unknownExtension_parser = LP.parse_bounded_seq_vlbytes 0 65535
 
 noextract let unknownExtension_serializer = LP.serialize_bounded_seq_vlbytes 0 65535
 
 let unknownExtension_bytesize_eq x = ()
 
-let unknownExtension_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let unknownExtension_validator = LSeqB.validate_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
-let unknownExtension_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let unknownExtension_jumper = LSeqB.jump_bounded_seq_vlbytes 0 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_unknownExtension = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_unknownExtension = LSeqB.copyful_parse_bounded_seq_vlbytes 0 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_unknownExtension : PPB.free_t unknownExtension_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_unknownExtension = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let write_unknownExtension = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
-let size_unknownExtension = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 (LSeqB.mk_seq_sizet 0 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let size_unknownExtension = LSeqB.l2r_safe_size_bounded_seq_vlbytes 0 0ul 65535 65535ul 2sz
 
 let unknownExtension_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 0 65535 x
 

--- a/generated/TLS13.Wire.Generated.UnknownName.fst
+++ b/generated/TLS13.Wire.Generated.UnknownName.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let unknownName_parser = LP.parse_bounded_seq_vlbytes 1 65535
 
 noextract let unknownName_serializer = LP.serialize_bounded_seq_vlbytes 1 65535
 
 let unknownName_bytesize_eq x = ()
 
-let unknownName_validator = LSeqB.validate_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let unknownName_validator = LSeqB.validate_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
-let unknownName_jumper = LSeqB.jump_bounded_seq_vlbytes 1 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 fits_u64_squash)) fits_u64_squash
+let unknownName_jumper = LSeqB.jump_bounded_seq_vlbytes 1 65535 (PPB.serialized_of_leaf_reader (LP.serialize_bounded_integer (LP.log256' 65535)) (PPBI.leaf_read_bounded_integer_2 ()))
 
-let read_unknownName = LSeqB.copyful_parse_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 fits_u64_squash) fits_u64_squash
+let read_unknownName = LSeqB.copyful_parse_bounded_seq_vlbytes 1 65535 (PPBI.leaf_read_bounded_integer_2 ())
 
 let free_unknownName : PPB.free_t unknownName_vmatch = fun x #v -> LSeqB.free_copy_seqbytes x #(Ghost.hide (Ghost.reveal v <: Seq.seq FStar.UInt8.t))
 
-let write_unknownName = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let write_unknownName = LSeqB.l2r_safe_writer_bounded_seq_vlbytes 1 1ul 65535 65535ul 2sz
 
-let size_unknownName = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 (LSeqB.mk_seq_sizet 1 fits_u64_squash) 65535 (LSeqB.mk_seq_sizet 65535 fits_u64_squash) 2sz fits_u64_squash
+let size_unknownName = LSeqB.l2r_safe_size_bounded_seq_vlbytes 1 1ul 65535 65535ul 2sz
 
 let unknownName_bytesize_eqn x = LP.length_serialize_bounded_seq_vlbytes 1 65535 x
 

--- a/scripts/build-everparse.sh
+++ b/scripts/build-everparse.sh
@@ -55,6 +55,7 @@ echo "Checking out pinned EverParse commit $EVERPARSE_COMMIT ..."
 git -C "$EVERPARSE_HOME" checkout --quiet "$EVERPARSE_COMMIT"
 
 echo "Building EverParse (make quackyducky -j$jobs) — this also builds F* and KaRaMeL ..."
+make -C "$EVERPARSE_HOME" -j"$jobs" deps && ADMIT=1 \
 make -C "$EVERPARSE_HOME" -j"$jobs" quackyducky
 
 for f in "$fstar_exe" "$krml_exe" "$qd_exe"; do

--- a/scripts/build-everparse.sh
+++ b/scripts/build-everparse.sh
@@ -12,12 +12,12 @@
 # F* install is required).
 set -euo pipefail
 
-EVERPARSE_REPO="${EVERPARSE_REPO:-https://github.com/tahina-pro/quackyducky}"
-EVERPARSE_BRANCH="${EVERPARSE_BRANCH:-_taramana_fstar2_qd_copyful}"
+EVERPARSE_REPO="${EVERPARSE_REPO:-https://github.com/project-everest/everparse}"
+EVERPARSE_BRANCH="${EVERPARSE_BRANCH:-fstar2}"
 # Pinned EverParse commit this project is verified against.  The branch above is
 # only used as a fetch hint; the build always checks out this exact commit so the
 # toolchain is reproducible regardless of where the branch tip has moved.
-EVERPARSE_COMMIT="${EVERPARSE_COMMIT:-7d4880c2}"
+EVERPARSE_COMMIT="${EVERPARSE_COMMIT:-6f1f390e0c8c376ce45facdb75c9af4e5aa3f11d}"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Default location: tools/everparse inside the agentic-tls checkout (matches the
@@ -27,7 +27,7 @@ EVERPARSE_HOME="${EVERPARSE_HOME:-$repo_root/tools/everparse}"
 jobs="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
 
 fstar_exe="$EVERPARSE_HOME/opt/FStar/out/bin/fstar.exe"
-krml_exe="$EVERPARSE_HOME/opt/FStar/karamel/out/bin/krml"
+krml_exe="$EVERPARSE_HOME/opt/karamel/out/bin/krml"
 qd_exe="$EVERPARSE_HOME/bin/qd.exe"
 
 for cmd in git make opam; do

--- a/src/impl/TLS13.Impl.Client.CanonicalProtocol.fst
+++ b/src/impl/TLS13.Impl.Client.CanonicalProtocol.fst
@@ -3797,6 +3797,7 @@ let lemma_client_local_fail_network_process_correct
 // cases: both are modeled as a purely local [LocalFail err] event with empty
 // raw_sent/raw_received deltas, so [consumed] and [produced] are both empty
 // and the [network_error_refines_state_machine] LocalEvent disjunct applies.
+#push-options "--z3rlimit 100"
 let lemma_client_local_fail_bridge_result
   (initial:CS.connection_state)
   (received0:B.bytes)
@@ -3969,6 +3970,7 @@ let lemma_client_local_fail_bridge_result
     initial received0 sent0 st0 input_contents input_len
     old_network_out network_out out_len base st1 app_out buffer_resp
     consumed wire_outputs local_outputs
+#pop-options
 
 let lemma_client_network_decode_error_bridge_result
   (initial:CS.connection_state)

--- a/src/impl/TLS13.Impl.Parser.fst
+++ b/src/impl/TLS13.Impl.Parser.fst
@@ -5409,6 +5409,17 @@ fn parse_handshake_message
                     fold (L.is_valid_tls_message
                             (L.LTlsHandshake (L.LServerHello lsh))
                             (M.TlsHandshake (Some?.v (RV.handshake_synth (Ghost.reveal gv)))));
+                    (* Prime the precondition of [lemma_handshake_wire_success_fixed]
+                       with focused asserts (mirroring the ClientHello arm): the
+                       [fold]s above bloat the slprop context, so proving the
+                       three-way conjunction in a single query is unstable.
+                       Splitting it into individual obligations keeps each Z3
+                       query small and deterministic. *)
+                    assert (pure (L.content_type_matches content_type T.Handshake));
+                    assert (pure (LP.parse GHS.handshake_parser (Ghost.reveal 'input_bytes) ==
+                                  Some (Ghost.reveal gv, B.length (Ghost.reveal 'input_bytes))));
+                    assert (pure (RV.handshake_synth (Ghost.reveal gv) ==
+                                  Some (Some?.v (RV.handshake_synth (Ghost.reveal gv)))));
                     lemma_handshake_wire_success_fixed content_type (Ghost.reveal 'input_bytes)
                       (Ghost.reveal gv) (Some?.v (RV.handshake_synth (Ghost.reveal gv)));
                     Some (L.LTlsHandshake (L.LServerHello lsh))

--- a/src/spec/TLS13.ConnectionLog.fst
+++ b/src/spec/TLS13.ConnectionLog.fst
@@ -1913,6 +1913,7 @@ let rec lemma_connection_view_consistent_note_app_received_chunks
 ///   (5) advances read_state.seq by exactly 1 from the k-chunk view
 /// Core can call this single lemma per loop iteration instead of combining several
 /// separate lemma calls inside the Pulse proof context.
+#push-options "--z3rlimit 100"
 let lemma_note_app_received_chunks_loop_step
   (view:connection_view)
   (chunks:list B.bytes)
@@ -1945,6 +1946,7 @@ let lemma_note_app_received_chunks_loop_step
   L.append_assoc view.app_view.app_received chunks [bytes];
   lemma_note_app_received_chunks_pending_fields view (chunks @ [bytes]);
   lemma_note_app_received_chunks_raw_log view (chunks @ [bytes])
+#pop-options
 
 let lemma_note_app_received_chunks_loop_accept_output
   (view:connection_view)

--- a/tftp_sample/Makefile
+++ b/tftp_sample/Makefile
@@ -28,7 +28,7 @@
 EVERPARSE_HOME ?= $(abspath ../tools/everparse)
 FSTAR_HOME ?= $(EVERPARSE_HOME)/opt/FStar
 FSTAR_EXE ?= $(FSTAR_HOME)/bin/fstar.exe
-KRML_HOME ?= $(FSTAR_HOME)/karamel
+KRML_HOME ?= $(EVERPARSE_HOME)/opt/karamel
 KRML ?= $(KRML_HOME)/out/bin/krml
 Z3_DIR ?= $(EVERPARSE_HOME)/opt/z3
 LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse

--- a/tftp_sample/extract_loops.sh
+++ b/tftp_sample/extract_loops.sh
@@ -9,7 +9,7 @@ set -e
 EP=${EVERPARSE_HOME:-/workspaces/agentic-tls/tools/everparse}
 FS=$EP/opt/FStar/bin/fstar.exe
 LP=$EP/src/lowparse
-KRML=$EP/opt/FStar/karamel/out/bin/krml
+KRML=$EP/opt/karamel/out/bin/krml
 export PATH=$EP/opt/z3:$PATH
 cd "$(dirname "$0")"
 F="--cache_checked_modules --cache_dir _cache --odir _output --already_cached Prims,FStar,Pulse,PulseCore,C,Spec.Loops,LowParse --warn_error -321-241-272-288 --report_assumes warn --ext optimize_let_vc --ext fly_deps --include ../common --include $LP --include $LP/pulse --include spec --include impl"

--- a/tftp_sample/impl/TFTP.Impl.Server.Loop.fst
+++ b/tftp_sample/impl/TFTP.Impl.Server.Loop.fst
@@ -490,6 +490,9 @@ ensures exists* (chr chs pr ps:TCP.bytes) (st1:TP.tftp_server_state)
       (* st_a == send_next_state st; re-derive the shifted plan facts at c+1. *)
       Plan.lemma_send_shift (Ghost.reveal contents) (SZ.v c) (Ghost.reveal nblocks);
       FStar.List.Tot.Properties.append_length st.TP.tss_sent [L.hd st.TP.tss_pending];
+      (* fits_u64-free FStar.SizeT derives `fits 516` only via fits_at_least_16's
+         SMTPat, which needs `516 < pow2 16` concretized here. *)
+      assert_norm (516 < pow2 16);
       FStar.SizeT.fits_lte (4 + SZ.v block_len_c) 516;
       let nw = TCP.write ch out (SZ.add 4sz block_len_c);
       let nr = TCP.read ch ackbuf 4sz;

--- a/tftp_sample/interop/Makefile
+++ b/tftp_sample/interop/Makefile
@@ -30,7 +30,7 @@ EXTRACT_DIR := $(PARENT)/_extract
 STUBS_DIR   := $(PARENT)/../c_stubs
 VERIFIED_DIR:= $(PARENT)/verified
 EVERPARSE_HOME ?= $(abspath $(PARENT)/../tools/everparse)
-KRML_HOME   ?= $(EVERPARSE_HOME)/opt/FStar/karamel
+KRML_HOME   ?= $(EVERPARSE_HOME)/opt/karamel
 KRML_INCLUDE = $(KRML_HOME)/include
 KRML_RUNTIME = $(KRML_HOME)/krmllib/dist/minimal
 

--- a/tls.qd.rfc
+++ b/tls.qd.rfc
@@ -49,8 +49,10 @@ enum {
     (255)
 } ContentType;
 
-enum {
-    /* [covered: this is the only suite emitted/accepted] */
+enum /*@open*/ {
+    /* [covered: 0x1303 selected; others (e.g. the 0x00FF SCSV that OpenSSL
+       always includes) must round-trip as unsupported so a peer ClientHello
+       offering extra suites still parses] */
     TLS_CHACHA20_POLY1305_SHA256(0x1303),
     (0xFFFF)
 } CipherSuite;

--- a/ymodem_sample/Makefile
+++ b/ymodem_sample/Makefile
@@ -30,7 +30,7 @@
 EVERPARSE_HOME ?= $(abspath ../tools/everparse)
 FSTAR_HOME ?= $(EVERPARSE_HOME)/opt/FStar
 FSTAR_EXE ?= $(FSTAR_HOME)/bin/fstar.exe
-KRML_HOME ?= $(FSTAR_HOME)/karamel
+KRML_HOME ?= $(EVERPARSE_HOME)/opt/karamel
 KRML ?= $(KRML_HOME)/out/bin/krml
 QD ?= $(EVERPARSE_HOME)/bin/qd.exe
 Z3_DIR ?= $(EVERPARSE_HOME)/opt/z3

--- a/ymodem_sample/extract_loops.sh
+++ b/ymodem_sample/extract_loops.sh
@@ -4,7 +4,7 @@ set -e
 EP=${EVERPARSE_HOME:-/home/taramana/agentic-tls/tools/everparse}
 FS=$EP/opt/FStar/bin/fstar.exe
 LP=$EP/src/lowparse
-KRML=$EP/opt/FStar/karamel/out/bin/krml
+KRML=$EP/opt/karamel/out/bin/krml
 cd "$(dirname "$0")"
 F="--cache_checked_modules --cache_dir _cache --odir _output --already_cached Prims,FStar,Pulse,PulseCore,C,Spec.Loops,LowParse --warn_error -321-241-272-288 --report_assumes warn --ext optimize_let_vc --ext fly_deps --include ../common --include $LP --include $LP/pulse --include spec --include impl"
 

--- a/ymodem_sample/impl/YModem.Impl.Codec.fst
+++ b/ymodem_sample/impl/YModem.Impl.Codec.fst
@@ -137,7 +137,7 @@ let crc_bytes_correct (hi lo: U8.t)
    per-region subgoals, so we ask for that split DETERMINISTICALLY (rather than
    relying on F*'s implicit, seed-sensitive fallback — cf. Warning 349).  The
    packaging helpers underneath then discharge trivially. *)
-#push-options "--z3rlimit 40 --fuel 2 --ifuel 2 --split_queries always"
+#push-options "--z3rlimit 100 --fuel 2 --ifuel 2 --split_queries always"
 
 (* Single heavy byte-equality lemma, shared by both leaves.  Its ONLY proof
    goal is one `Seq.lemma_eq_intro` (a 133-element pointwise forall), so the

--- a/ymodem_sample/spec/YModem.Wire.Generated.Ymodem_empty.fst
+++ b/ymodem_sample/spec/YModem.Wire.Generated.Ymodem_empty.fst
@@ -35,25 +35,23 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let ymodem_empty_parser = LP.parse_empty
 
 noextract let ymodem_empty_serializer = LP.serialize_empty
 
 let ymodem_empty_bytesize_eq x = ()
 
-let ymodem_empty_reader = PPC.leaf_read_empty
+let ymodem_empty_reader = fun input #pm #v -> (PPC.leaf_read_empty) input #pm #v
 
-let ymodem_empty_writer = LPC.l2r_leaf_write_empty
+let ymodem_empty_writer = fun x out offset #v -> (LPC.l2r_leaf_write_empty) x out offset #v
 
-let ymodem_empty_leaf_size = LPC.leaf_size_empty
+let ymodem_empty_leaf_size = fun x -> (LPC.leaf_size_empty) x
 
-let read_ymodem_empty : PPB.copyful_parse ymodem_empty_vmatch ymodem_empty_parser ymodem_empty_conv = (PPB.copyful_parse_leaf PPC.leaf_read_empty)
+let read_ymodem_empty : PPB.copyful_parse ymodem_empty_vmatch ymodem_empty_parser ymodem_empty_conv = fun input #pm #v -> ((PPB.copyful_parse_leaf PPC.leaf_read_empty)) input #pm #v
 
-let free_ymodem_empty : PPB.free_t ymodem_empty_vmatch = (PPB.free_leaf #unit)
+let free_ymodem_empty : PPB.free_t ymodem_empty_vmatch = fun x #v -> ((PPB.free_leaf #unit)) x #v
 
-let write_ymodem_empty : PPB.l2r_safe_writer ymodem_empty_vmatch ymodem_empty_serializer ymodem_empty_conv = (PPB.l2r_safe_writer_leaf LP.serialize_empty 0sz LPC.l2r_leaf_write_empty)
+let write_ymodem_empty : PPB.l2r_safe_writer ymodem_empty_vmatch ymodem_empty_serializer ymodem_empty_conv = fun x #y out #v perr -> ((PPB.l2r_safe_writer_leaf LP.serialize_empty 0sz LPC.l2r_leaf_write_empty)) x #y out #v perr
 
 let ymodem_empty_bytesize_eqn x = (assert (FStar.Seq.length (LP.serialize LP.serialize_empty (x)) == 0))
 

--- a/ymodem_sample/spec/YModem.Wire.Generated.Ymodem_message.fst
+++ b/ymodem_sample/spec/YModem.Wire.Generated.Ymodem_message.fst
@@ -37,8 +37,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 // Need high Z3 limits for large sum types
 #set-options "--z3rlimit 360"
 
@@ -113,7 +111,7 @@ noextract inline_for_extraction let synth_ymodem_message_cases_recip (k:LP.enum_
   | Crc_c -> [@inline_let] let _ = synth_ymodem_message_cases_recip_pre_intro Crc_c x in
     (match x with Body_crc_c y -> (from_ymodem_message_case_of_ymodem_tag Crc_c y))
 
-inline_for_extraction let ymodem_message_sum = LP.make_sum' ymodem_tag_enum key_of_ymodem_message
+inline_for_extraction noextract let ymodem_message_sum = LP.make_sum' ymodem_tag_enum key_of_ymodem_message
   ymodem_message_case_of_ymodem_tag synth_ymodem_message_cases synth_ymodem_message_cases_recip
   (_ by (LP.make_sum_synth_case_recip_synth_case_tac ()))
   (_ by (LP.synth_case_synth_case_recip_tac ()))

--- a/ymodem_sample/spec/YModem.Wire.Generated.Ymodem_soh_body.fst
+++ b/ymodem_sample/spec/YModem.Wire.Generated.Ymodem_soh_body.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 (* Type of field data*)
 open YModem.Wire.Generated.Ymodem_soh_body_data
 
@@ -77,7 +75,7 @@ let read_ymodem_soh_body : PPB.copyful_parse ymodem_soh_body_vmatch ymodem_soh_b
   assert_norm (ymodem_soh_body_parser_kind == ymodem_soh_body'_parser_kind);
   PPC.copyful_parse_synth (PPC.copyful_parse_pair (LPC.jump_nondep_then LPPI.jump_u8 LPPI.jump_u8) (PPC.copyful_parse_pair LPPI.jump_u8 (PPB.copyful_parse_leaf (PPB.leaf_reader_of_serialized (LPPI.read_u8' ()))) () (PPB.copyful_parse_leaf (PPB.leaf_reader_of_serialized (LPPI.read_u8' ())))) () (PPC.copyful_parse_pair ymodem_soh_body_data_jumper read_ymodem_soh_body_data () (PPB.copyful_parse_leaf (PPB.leaf_reader_of_serialized (LPPI.read_u16' ()))))) synth_ymodem_soh_body synth_ymodem_soh_body_recip
 
-let free_ymodem_soh_body : PPB.free_t ymodem_soh_body_vmatch = (PPC.free_pair (PPC.free_pair (PPB.free_leaf #U8.t) (PPB.free_leaf #U8.t)) (PPC.free_pair free_ymodem_soh_body_data (PPB.free_leaf #U16.t)))
+let free_ymodem_soh_body : PPB.free_t ymodem_soh_body_vmatch = fun x #v -> ((PPC.free_pair (PPC.free_pair (PPB.free_leaf #U8.t) (PPB.free_leaf #U8.t)) (PPC.free_pair free_ymodem_soh_body_data (PPB.free_leaf #U16.t)))) x #v
 
 let write_ymodem_soh_body : PPB.l2r_safe_writer ymodem_soh_body_vmatch ymodem_soh_body_serializer ymodem_soh_body_conv =
   synth_ymodem_soh_body_injective ();
@@ -86,7 +84,7 @@ let write_ymodem_soh_body : PPB.l2r_safe_writer ymodem_soh_body_vmatch ymodem_so
 
 let size_ymodem_soh_body : PPB.l2r_safe_size ymodem_soh_body_vmatch ymodem_soh_body_serializer ymodem_soh_body_conv =
   synth_ymodem_soh_body_injective ();
-  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair fits_u64_squash (PPC.l2r_safe_size_pair fits_u64_squash (PPB.l2r_safe_size_leaf LPI.serialize_u8 1sz) () (PPB.l2r_safe_size_leaf LPI.serialize_u8 1sz)) () (PPC.l2r_safe_size_pair fits_u64_squash size_ymodem_soh_body_data () (PPB.l2r_safe_size_leaf LPI.serialize_u16 2sz))) synth_ymodem_soh_body synth_ymodem_soh_body_recip
+  PPC.l2r_safe_size_synth (PPC.l2r_safe_size_pair (PPC.l2r_safe_size_pair (PPB.l2r_safe_size_leaf LPI.serialize_u8 1sz) () (PPB.l2r_safe_size_leaf LPI.serialize_u8 1sz)) () (PPC.l2r_safe_size_pair size_ymodem_soh_body_data () (PPB.l2r_safe_size_leaf LPI.serialize_u16 2sz))) synth_ymodem_soh_body synth_ymodem_soh_body_recip
 
 let ymodem_soh_body_bytesize_eqn x =
   [@inline_let] let _ = synth_ymodem_soh_body_injective () in

--- a/ymodem_sample/spec/YModem.Wire.Generated.Ymodem_soh_body_data.fst
+++ b/ymodem_sample/spec/YModem.Wire.Generated.Ymodem_soh_body_data.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let ymodem_soh_body_data_parser = LP.parse_lseq_bytes 128
 
 noextract let ymodem_soh_body_data_serializer = LP.serialize_lseq_bytes 128

--- a/ymodem_sample/spec/YModem.Wire.Generated.Ymodem_tag.fst
+++ b/ymodem_sample/spec/YModem.Wire.Generated.Ymodem_tag.fst
@@ -35,8 +35,6 @@ module LPITE = LowParse.PulseParse.IfThenElse
 
 #reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit 16 --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2"
 
-assume val fits_u64_squash : squash FStar.SizeT.fits_u64
-
 noextract let ymodem_tag_repr_parser = LPI.parse_u8
 
 noextract let ymodem_tag_repr_serializer = LPI.serialize_u8
@@ -49,9 +47,9 @@ inline_for_extraction noextract let ymodem_tag_repr_reader = (PPB.leaf_reader_of
 
 inline_for_extraction noextract let ymodem_tag_repr_writer = (LPPI.l2r_leaf_write_u8 ())
 
-inline_for_extraction let synth_ymodem_tag (x: LP.enum_key ymodem_tag_enum) : Tot ymodem_tag = x
+inline_for_extraction noextract let synth_ymodem_tag (x: LP.enum_key ymodem_tag_enum) : Tot ymodem_tag = x
 
-inline_for_extraction let synth_ymodem_tag_inv (x: ymodem_tag) : Tot (LP.enum_key ymodem_tag_enum) =
+inline_for_extraction noextract let synth_ymodem_tag_inv (x: ymodem_tag) : Tot (LP.enum_key ymodem_tag_enum) =
   [@inline_let] let _ : squash (LP.list_mem x (LP.list_map fst ymodem_tag_enum)) =
     _ by (LP.synth_maybe_enum_key_inv_unknown_tac x)
   in


### PR DESCRIPTION
## Summary

This branch retargets the whole verification toolchain from a personal
QuackyDucky fork to **upstream EverParse's `fstar2` branch** (which now builds
its own KaRaMeL), ports every QuackyDucky‑generated wire parser **and** the TLS
`src/` proofs to the new **fits_u64‑free** `FStar.SizeT` / `LowParse.Pulse`, and
lands a **full CI pipeline** built around the dev container.

Along the way it fixes one behavioural regression (`CipherSuite` silently became
a *closed* enum under the stricter grammar, breaking OpenSSL interop) and
stabilizes a handful of proofs that drifted under the upgraded F*/Z3.

**Scope:** 121 files changed, 753 insertions(+), 544 deletions(−). The bulk is
regenerated `*.Wire.Generated.*` parser/serializer code; only 18 files are
hand‑edited source, build, or CI.

NOTE: This PR pins EverParse to project-everest/everparse@6f1f390e0c8c376ce45facdb75c9af4e5aa3f11d, itself pinning F* to [Release v2026.07.12](https://github.com/FStarLang/FStar/releases/tag/v2026.07.12).
It does not handle Pulse termination yet.

---

## 1. Toolchain upgrade: upstream EverParse `fstar2` with its own KaRaMeL

`scripts/build-everparse.sh`:

- Repo/branch: `tahina-pro/quackyducky` @ `_taramana_fstar2_qd_copyful`
  → **`project-everest/everparse` @ `fstar2`**.
- Pinned commit: `7d4880c2` → **`6f1f390e0c8c376ce45facdb75c9af4e5aa3f11d`**.
- KaRaMeL now lives at **`opt/karamel`** (EverParse builds its own) rather than
  `opt/FStar/karamel`.
- Build invocation now runs `make deps` first and builds QuackyDucky with
  `ADMIT=1` (Z3 is still installed).

The `opt/FStar/karamel` → `opt/karamel` `KRML_HOME`/`KRML` path move is threaded
through every build harness that referenced it:

- `Makefile`, `calc_sample/Makefile`, `tftp_sample/Makefile`,
  `ymodem_sample/Makefile`, `tftp_sample/interop/Makefile`
- `tftp_sample/extract_loops.sh`, `ymodem_sample/extract_loops.sh`

## 2. Port generated wire parsers to fits_u64‑free EverParse

The `fstar2` QuackyDucky's `-pulse` output no longer threads
`FStar.SizeT.fits_u64` squashes through the low‑level
parser/serializer/validator combinators (it uses the base‑2¹⁵ `SizeComparison`
helpers instead), so the previously committed generated sources no longer
typecheck against the upgraded `LowParse.Pulse`.

- **`generated/TLS13.Wire.Generated.*`** regenerated — e.g. the boilerplate
  `assume val fits_u64_squash : squash FStar.SizeT.fits_u64` is gone from every
  module. Public `.fsti` signatures are unchanged apart from `CipherSuite`
  (see below); the hand‑written spec/impl needs no wire‑type changes.
- **`ymodem_sample/spec/YModem.Wire.Generated.*`** and
  **`ftp_sample/spec/FTPBlock.Wire.Generated.*`** regenerated the same way.
  Their enums (`ymodem_tag`, and FTP has none) are already closed, so there is
  no open/closed regression there.

## 3. Fix: keep `CipherSuite` an **open** enum (interop‑critical)

The new QuackyDucky honours the grammar strictly — an enum without an explicit
`/*@open*/` annotation is **closed**. `CipherSuite` had only a `0xFFFF` ceiling
and no `@open`, so it regenerated closed, dropping `Unknown_cipherSuite`.

That breaks server interop: OpenSSL's ClientHello always lists the `0x00FF`
`TLS_EMPTY_RENEGOTIATION_INFO_SCSV` alongside `0x1303`, and a closed parser
rejects it — the extracted server replied with **alert 50 / decode_error**.

Fix in `tls.qd.rfc`: mark `CipherSuite /*@open*/` so unknown suites round‑trip
as before, restoring the open enum the previous toolchain produced. `src/` needs
no cipher‑suite changes.

## 4. Proof stabilizations under the upgraded F*/Z3

- **`src/impl/TLS13.Impl.Parser.fst`** — the ServerHello
  (`TLS_CHACHA20_POLY1305_SHA256`) arm of `parse_handshake_message` became
  unstable (intermittent Z3 Error 19). Prime the precondition of
  `lemma_handshake_wire_success_fixed` with three focused `assert (pure …)`
  obligations (mirroring the ClientHello arm) so each Z3 query stays small and
  deterministic. Re‑checked across Z3 seeds 1, 2, 4, 7.
- **`src/spec/TLS13.ConnectionLog.fst`** — `#push-options --z3rlimit 100`
  around `lemma_note_app_received_chunks_loop_step`.
- **`src/impl/TLS13.Impl.Client.CanonicalProtocol.fst`** — `#push-options
  --z3rlimit 100` around `lemma_client_local_fail_bridge_result`.
- **`tftp_sample/impl/TFTP.Impl.Server.Loop.fst`** — TFTP's wire format is
  hand‑written (nothing to regenerate); the only breakage was
  `fits_lte (4 + block_len) 516`, whose `fits 516` precondition is no longer
  discharged automatically. Fixed with `assert_norm (516 < pow2 16)` so the
  `fits_at_least_16` SMTPat fires.
- **`ymodem_sample/impl/YModem.Impl.Codec.fst`** — bump `z3rlimit 40 → 100` on
  `serialize_soh_eq`.

## 5. Samples

- **`ftp_sample/Makefile`** (new) — `ftp_sample` was the only sample without a
  build harness. Adds a **spec‑only** Makefile mirroring the siblings'
  toolchain wiring, exposing `verify` (default), `gen`, `check-admits`, `clean`
  (no impl/C‑extraction/interop layer).
- **`ymodem_sample`** / **`tftp_sample`** — regenerated / fixed as described
  above; `vloop-test` (verify + extract verified loops + socketpair transfer)
  passes for both.

## 6. CI pipeline + dev container

- **`.github/workflows/ci.yml`** (new, 203 lines) — replaces the placeholder
  workflow with a real pipeline:
  1. A `devcontainer` job builds the image and runs `./setup.sh` to build the
     EverParse/F*/KaRaMeL toolchain once (~1h), then commits a **toolchain‑only**
     image (source stripped, `tools/everparse` + `third_party` kept) and stores
     it in the **GitHub Actions cache** — keyed on `hashFiles(Dockerfile,
     setup.sh, scripts/build-everparse.sh)`, so ordinary source edits reuse it.
  2. A `tests` matrix runs **five targets in parallel** (`fail-fast: false`),
     each loading the cached image and injecting fresh source: `make test`,
     `calc_sample test-c`, `ftp_sample`, `ymodem_sample vloop-test + interop`,
     `tftp_sample vloop-test + interop`.
  3. A `ci-success` gate requires all of them to pass (single status check).
- **`.devcontainer/Dockerfile`** — add `time` (needed to build KaRaMeL) and
  `lrzsz` (the `sb`/`rb` reference tools for `ymodem_sample` interop; previously
  those tests always skipped).
- **`Makefile`** — add `save-generated-cache` / `restore-generated-cache`
  targets that export/import the generated `.checked` verification result as a
  single relocatable tarball. CI caches it keyed on
  `hashFiles(build-everparse.sh, tls.qd.rfc)`, saving the ~9‑min generated‑parser
  verification on every `tls-root` run. F* still re‑validates each `.checked`
  against its source hash when the main build consumes it, so a stale cache is
  safely re‑verified rather than trusted.
- **`.gitignore`** — ignore `generated-checked.tar.gz`.

---

## Validation

Per the individual commits, all run from a clean build in the dev container:

- `make -j16 test` — verify + OpenSSL echo / `s_client` interop — passes.
- `make -j16 -C ftp_sample verify` — passes.
- `make -j16 -C ymodem_sample vloop-test` and its interop (extracted `sb`/`rb`
  ↔ lrzsz) — pass.
- `make -j16 -C tftp_sample vloop-test` and its interop (extracted server ↔
  `tftp-hpa`) — pass.
- `make _cache/TLS13.Impl.Parser.fst.checked` — passes; re‑checked across Z3
  seeds 1, 2, 4, 7.
- The CI workflow was validated with `actionlint` and by exercising the
  build/commit/save/load + source‑injection mechanism and all five test
  commands in the dev container.
