### PR TITLE
Upgrade EverParse and add Pulse `decreases` clauses for termination checking

### DIFF
--- a/calc_sample/impl/Calc.Server.Endpoint.fst
+++ b/calc_sample/impl/Calc.Server.Endpoint.fst
@@ -1812,6 +1812,7 @@ ensures
         (Ghost.reveal sent_loop)
         (Ghost.reveal log_loop) **
       pure (SZ.v (R.read remaining) <= SZ.v fuel)
+  decreases %[(if !running then 1 else 0); SZ.v (!remaining)]
   {
     with rem_live keep_live received_loop sent_loop log_loop.
       assert (

--- a/calc_sample/impl/Calc.Server.Socket.fst
+++ b/calc_sample/impl/Calc.Server.Socket.fst
@@ -105,6 +105,7 @@ ensures
             Vec.is_full_vec srv.stack /\
             Vec.is_full_vec srv.size /\
             SZ.v (R.read remaining) <= SZ.v fuel)
+      decreases %[(if !running then 1 else 0); SZ.v (!remaining)]
       {
         with rem_live keep_live received_loop sent_loop log_loop req_bytes_loop resp_bytes_loop.
           assert (

--- a/scripts/build-everparse.sh
+++ b/scripts/build-everparse.sh
@@ -17,7 +17,7 @@ EVERPARSE_BRANCH="${EVERPARSE_BRANCH:-fstar2}"
 # Pinned EverParse commit this project is verified against.  The branch above is
 # only used as a fetch hint; the build always checks out this exact commit so the
 # toolchain is reproducible regardless of where the branch tip has moved.
-EVERPARSE_COMMIT="${EVERPARSE_COMMIT:-6f1f390e0c8c376ce45facdb75c9af4e5aa3f11d}"
+EVERPARSE_COMMIT="${EVERPARSE_COMMIT:-ad56c6dbcf2c743a5f90600d210a1c1c3d29aff4}"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Default location: tools/everparse inside the agentic-tls checkout (matches the

--- a/src/impl/TLS13.Impl.Client.Driver.Core.fst
+++ b/src/impl/TLS13.Impl.Client.Driver.Core.fst
@@ -1179,6 +1179,7 @@ fn compact_buffer_suffix
               (forall (k:nat). SZ.v (R.read i) <= k /\ k < SZ.v buffered_len ==>
                 Seq.index raw_loop k ==
                 Seq.index (Ghost.reveal 'raw_bytes) k))
+      decreases (SZ.v new_len - SZ.v (R.read i))
     {
       let vi = R.read i;
       assert (pure (SZ.v vi < SZ.v new_len));

--- a/src/impl/TLS13.Impl.Parser.fst
+++ b/src/impl/TLS13.Impl.Parser.fst
@@ -1264,6 +1264,7 @@ fn build_ch_cipher_suites
               (RV.reveal_synth_cipher_suites
                 (RV.list_drop (SZ.v iv) (Ghost.reveal cm))) ==
               RV.reveal_synth_cipher_suites (Ghost.reveal cm))
+        decreases (SZ.v count - SZ.v (!i))
         {
           let iv = !i;
           with bytes0 processed0. assert (V.pts_to dst bytes0 ** GR.pts_to proc_ref processed0);
@@ -1456,6 +1457,7 @@ fn copy_ch_signature_schemes_into
               (RV.reveal_synth_sig_schemes
                 (RV.list_drop (SZ.v iv) (Ghost.reveal cm))) ==
               RV.reveal_synth_sig_schemes (Ghost.reveal cm))
+        decreases (SZ.v count - SZ.v (!i))
         {
           let iv = !i;
           with bytes0 processed0. assert (V.pts_to dst bytes0 ** GR.pts_to proc_ref processed0);
@@ -2718,6 +2720,7 @@ fn scan_ee_alpn
                     SZ.v al <= 255 /\
                     L.optional_byte_prefix_matches true abytes al
                       (Some?.v (RV.reveal_synth_encrypted_extensions cee)))))
+      decreases %[(if !found then 0 else 1); (SZ.v count - SZ.v (!i))]
       {
         let iv = !i;
         assert (pure (SZ.v iv < FStar.List.Tot.length cee));
@@ -3602,6 +3605,7 @@ fn scan_sh_key_share
             RV.reveal_sh_key_share cext false None ==
             RV.reveal_sh_key_share (RV.list_drop (SZ.v iv) cext) svb kacc)
         )
+      decreases %[(if !failed then 0 else 1); (SZ.v count - SZ.v (!i))]
       {
         let iv = !i;
         assert (pure (SZ.v iv < FStar.List.Tot.length cext));
@@ -3954,6 +3958,7 @@ fn scan_ch_supported_versions
           ((not f) ==> (FStar.List.Tot.mem GPV.TLS_1p3 (Ghost.reveal cm) <==>
                         FStar.List.Tot.mem GPV.TLS_1p3
                           (RV.list_drop (SZ.v iv) (Ghost.reveal cm)))))
+      decreases %[(if !found_ref then 0 else 1); (SZ.v count - SZ.v (!i))]
       {
         let iv = !i;
         assert (pure (SZ.v iv < FStar.List.Tot.length (Ghost.reveal cm)));
@@ -4101,6 +4106,7 @@ fn scan_ch_key_share
           ((not d) ==> found == false /\
             TLS13.Wire.Semantics.kse_list_find_x25519 (Ghost.reveal cm) ==
             TLS13.Wire.Semantics.kse_list_find_x25519 (RV.list_drop (SZ.v iv) (Ghost.reveal cm))))
+      decreases %[(if !done_ref then 0 else 1); (SZ.v count - SZ.v (!i))]
       {
         let iv = !i;
         assert (pure (SZ.v iv < FStar.List.Tot.length (Ghost.reveal cm)));
@@ -4324,6 +4330,7 @@ fn scan_ch_extensions
             RV.reveal_ch_extensions (Ghost.reveal cext) None None false [] ==
             RV.reveal_ch_extensions (RV.list_drop (SZ.v iv) (Ghost.reveal cext))
               sn_acc key_acc sv (Ghost.reveal sig_acc)))
+      decreases %[(if !failed then 0 else 1); (SZ.v count - SZ.v (!i))]
       {
         let iv = !i;
         with sn_bytes0 kbytes0 sig_bytes0 sn_acc0 key_acc0 sig_acc0.
@@ -5025,6 +5032,7 @@ fn scan_certificate_chain
                 (RV.reveal_synth_cert_chain (RV.list_drop (SZ.v iv) cm))
                 == RV.reveal_synth_cert_chain cm)))
         )
+      decreases %[(if !failed then 0 else 1); (SZ.v count - SZ.v (!i))]
       {
         let iv = !i;
         let cntv = !cnt_ref;

--- a/src/impl/TLS13.Impl.Serializer.Handshake.fst
+++ b/src/impl/TLS13.Impl.Serializer.Handshake.fst
@@ -1801,6 +1801,7 @@ fn mk_vclist_from_u16_leaf_array
     V.pts_to vec s1 **
     SM.seq_seq_match (PPB.vmatch_conv elem_vmatch elem_conv) s1 (Ghost.reveal sl) 0 (SZ.v i) **
     pure (1 <= SZ.v i /\ SZ.v i <= SZ.v n /\ V.is_full_vec vec /\ Seq.length s1 == SZ.v n)
+  decreases (SZ.v n - SZ.v (!pi))
   {
     let i = !pi;
     with s1. assert (V.pts_to vec s1);

--- a/src/impl/TLS13.Impl.Serializer.fst
+++ b/src/impl/TLS13.Impl.Serializer.fst
@@ -1013,6 +1013,7 @@ fn build_server_certificate_verify_input
               cv_context_index k) /\
             (forall (k:nat). SZ.v (Ref.read i) <= k /\ k < 34 ==>
               Seq.index context_loop k == 0uy))
+    decreases (34 - SZ.v (Ref.read i))
   {
     let vi = Ref.read i;
     assert (pure (SZ.v vi < 34));

--- a/src/impl/TLS13.Impl.Server.Driver.Network.fst
+++ b/src/impl/TLS13.Impl.Server.Driver.Network.fst
@@ -118,6 +118,7 @@ fn compact_buffer_suffix
               (forall (k:nat). SZ.v (R.read i) <= k /\ k < SZ.v buffered_len ==>
                 Seq.index raw_loop k ==
                 Seq.index (Ghost.reveal 'raw_bytes) k))
+      decreases (SZ.v new_len - SZ.v (R.read i))
     {
       let vi = R.read i;
       assert (pure (SZ.v vi < SZ.v new_len));

--- a/src/impl/TLS13.Impl.Server.Endpoint.fst
+++ b/src/impl/TLS13.Impl.Server.Endpoint.fst
@@ -2519,6 +2519,7 @@ fn server_compact_buffer_suffix
               (forall (k:nat). SZ.v (R.read i) <= k /\ k < SZ.v buffered_len ==>
                 Seq.index raw_loop k ==
                 Seq.index (Ghost.reveal 'raw_bytes) k))
+      decreases (SZ.v new_len - SZ.v (R.read i))
     {
       let vi = R.read i;
       assert (pure (SZ.v vi < SZ.v new_len));
@@ -3517,7 +3518,7 @@ fn server_decrement_endpoint_fuel
                  SZ.v (Ghost.reveal 'rem) <= SZ.v fuel)
   ensures exists* rem1.
             R.pts_to remaining rem1 **
-            pure (SZ.v rem1 <= SZ.v fuel)
+            pure (SZ.v rem1 < SZ.v (Ghost.reveal 'rem) /\ SZ.v rem1 <= SZ.v fuel)
 {
   let rem_now = R.read remaining;
   assert (pure (not (rem_now = 0sz)));
@@ -3632,6 +3633,7 @@ fn server_finish_network_result_iteration
             R.pts_to last_status last_status1 **
             R.pts_to remaining rem1 **
             pure (SZ.v buffered_len1 <= SZ.v frame.server_ep_raw_len /\
+                  SZ.v rem1 < SZ.v (Ghost.reveal 'rem) /\
                   SZ.v rem1 <= SZ.v fuel)
 {
   last_status := result.CPI.process_status;
@@ -3791,6 +3793,7 @@ fn server_endpoint_run_workflow
       Box.pts_to buffered_len_ref buffered_len_loop **
       pure (SZ.v buffered_len_loop <= SZ.v frame.server_ep_raw_len /\
             SZ.v (R.read remaining) <= SZ.v fuel)
+  decreases %[(if !running then 1 else 0); SZ.v (!remaining)]
   {
     with received_loop sent_loop st_loop buffered_len_loop.
       assert (

--- a/src/impl/TLS13.Impl.Server.Send.fst
+++ b/src/impl/TLS13.Impl.Server.Send.fst
@@ -688,6 +688,7 @@ fn server_random_differs_from_cst (material: array U8.t) (#p: perm) (#mb: erased
     Ref.pts_to all_equal ae **
     pure (SZ.v je <= 32 /\ B.length mb >= 32 /\
           (ae <==> (forall (k:nat). k < SZ.v je ==> Seq.index mb k == Seq.index GSHbody.serverHello_body_cst k)))
+  decreases (32 - SZ.v (Ref.read j))
   {
     let jv = Ref.read j;
     let mv = material.(jv);

--- a/tftp_sample/impl/TFTP.Impl.Client.Loop.fst
+++ b/tftp_sample/impl/TFTP.Impl.Client.Loop.fst
@@ -302,12 +302,14 @@ fn read_status_update
 requires
   CC.tftp_client_inv i received sent st **
   R.pts_to running rn0 **
-  R.pts_to remaining f0
+  R.pts_to remaining f0 **
+  pure (not (Ghost.reveal f0 = 0sz))
 returns _:unit
 ensures exists* (rn1:bool) (f1:SZ.t).
   CC.tftp_client_inv i received sent st **
   R.pts_to running rn1 **
-  R.pts_to remaining f1
+  R.pts_to remaining f1 **
+  pure (rn1 == false \/ (rn1 == Ghost.reveal rn0 /\ SZ.v f1 < SZ.v (Ghost.reveal f0)))
 {
   unfold (CC.tftp_client_inv i received sent st);
   with svs. _;
@@ -376,6 +378,7 @@ ensures exists* (chr chs pr ps:TCP.bytes) (st1:TP.tftp_client_state)
       R.pts_to cursor cv **
       pure (Seq.length ib == 516 /\ Seq.length sc == 512 /\ Seq.length ac == 4 /\
             Seq.length ob == SZ.v outcap /\ SZ.v cv <= SZ.v outcap)
+  decreases %[(if !running then 1 else 0); SZ.v (!remaining)]
   {
     (* read one whole datagram (n = its length, n <= 516) *)
     let n = TCP.read ch inbuf 516sz;

--- a/tftp_sample/impl/TFTP.Impl.Codec.fst
+++ b/tftp_sample/impl/TFTP.Impl.Codec.fst
@@ -325,6 +325,7 @@ fn tftp_emit_data
       Seq.index sv 2 == u16_hi blk /\
       Seq.index sv 3 == u16_lo blk /\
       (forall (j:nat). j < SZ.v vi ==> Seq.index sv (4 + j) == Seq.index 'd j))
+  decreases (Prims.op_Subtraction (SZ.v data_len) (SZ.v (!i)))
   {
     let vi = !i;
     let dv = data.(vi);
@@ -396,6 +397,7 @@ fn tftp_recv_data
       Seq.length 'i == SZ.v inp_len /\
       SZ.v inp_len == Seq.length ov + 4 /\
       (forall (j:nat). j < SZ.v vi ==> Seq.index ov j == Seq.index 'i (4 + j)))
+  decreases (Prims.op_Subtraction (SZ.v plen) (SZ.v (!i)))
   {
     let vi = !i;
     let dv = inp.(4sz + vi);
@@ -476,6 +478,7 @@ fn tftp_emit_rrq
       Seq.index sv 0 == u16_hi op_rrq /\
       Seq.index sv 1 == u16_lo op_rrq /\
       (forall (j:nat). j < SZ.v vi ==> Seq.index sv (2 + j) == Seq.index 'fnb j))
+  decreases (Prims.op_Subtraction (SZ.v fn_len) (SZ.v (!i)))
   {
     let vi = !i;
     let dv = filename.(vi);
@@ -500,6 +503,7 @@ fn tftp_emit_rrq
       Seq.index sv (2 + SZ.v fn_len) == 0uy /\
       (forall (j:nat). j < SZ.v vk ==>
          Seq.index sv (2 + SZ.v fn_len + 1 + j) == Seq.index 'mdb j))
+  decreases (Prims.op_Subtraction (SZ.v mode_len) (SZ.v (!k)))
   {
     let vk = !k;
     let dv = mode.(vk);
@@ -556,6 +560,7 @@ fn tftp_emit_error
       Seq.index sv 2 == u16_hi code /\
       Seq.index sv 3 == u16_lo code /\
       (forall (j:nat). j < SZ.v vi ==> Seq.index sv (4 + j) == Seq.index 'em j))
+  decreases (Prims.op_Subtraction (SZ.v msg_len) (SZ.v (!i)))
   {
     let vi = !i;
     let dv = msg.(vi);

--- a/tftp_sample/impl/TFTP.Impl.Server.Loop.fst
+++ b/tftp_sample/impl/TFTP.Impl.Server.Loop.fst
@@ -194,6 +194,7 @@ ensures exists* (st1:TP.tftp_server_state) (nsent:TCP.bytes) (oc':Seq.seq U8.t).
     pts_to data dc **
     pts_to out od **
     pure (SZ.v vj <= SZ.v data_len /\ SZ.v data_len <= 512 /\ Seq.length od == 516)
+  decreases (SZ.v data_len - SZ.v (!j))
   {
     let vj = !j;
     let dv = data.(vj);
@@ -369,6 +370,7 @@ ensures exists* (d1:Seq.seq U8.t).
           SZ.fits (SZ.v off + SZ.v len) /\
           (forall (k:nat). k < SZ.v vj ==>
              Seq.index d k == Seq.index (Ghost.reveal contents) (SZ.v off + k)))
+  decreases (SZ.v len - SZ.v (!j))
   {
     let vj = !j;
     FStar.SizeT.fits_lte (SZ.v off + SZ.v vj) (SZ.v off + SZ.v len);
@@ -459,6 +461,7 @@ ensures exists* (chr chs pr ps:TCP.bytes) (st1:TP.tftp_server_state)
             (rv == true ==>
               loop_coupling (Ghost.reveal contents) (Ghost.reveal nblocks)
                 (Ghost.reveal filename) st cv))
+  decreases %[(if !running then 1 else 0); SZ.v (!remaining)]
   {
     with st cv. _;
     assert (pure (loop_coupling (Ghost.reveal contents) (Ghost.reveal nblocks)

--- a/ymodem_sample/impl/YModem.Impl.Client.Loop.fst
+++ b/ymodem_sample/impl/YModem.Impl.Client.Loop.fst
@@ -262,12 +262,14 @@ fn read_status_update
 requires
   CC.ymodem_client_inv i received sent st **
   R.pts_to running rn0 **
-  R.pts_to remaining f0
+  R.pts_to remaining f0 **
+  pure (not (Ghost.reveal f0 = 0sz))
 returns _:unit
 ensures exists* (rn1:bool) (f1:SZ.t).
   CC.ymodem_client_inv i received sent st **
   R.pts_to running rn1 **
-  R.pts_to remaining f1
+  R.pts_to remaining f1 **
+  pure (rn1 == false \/ (rn1 == Ghost.reveal rn0 /\ SZ.v f1 < SZ.v (Ghost.reveal f0)))
 {
   unfold (CC.ymodem_client_inv i received sent st);
   with svs. _;
@@ -345,6 +347,7 @@ ensures exists* (chr chs pr ps:TCP.bytes) (st1:YP.ymodem_client_state)
       pure (Seq.length c == 1 /\ Seq.length so == 133 /\ Seq.length t == 132 /\
             Seq.length a == 1 /\ Seq.length y == 128 /\ Seq.length o == SZ.v outcap /\
             SZ.v cv <= SZ.v outcap)
+  decreases %[(if !running then 1 else 0); SZ.v (!remaining)]
   {
     let nlead = TCP.read_full ch ctrl 1sz;
     let lead = ctrl.(0sz);

--- a/ymodem_sample/impl/YModem.Impl.Codec.fst
+++ b/ymodem_sample/impl/YModem.Impl.Codec.fst
@@ -300,6 +300,7 @@ fn ymodem_emit_data_block
     R.pts_to c cv **
     pts_to data 'd **
     pure (SZ.v cv <= 128 /\ Seq.length 'd == 128)
+  decreases (Prims.op_Subtraction 128 (SZ.v (!c)))
   {
     let cv = !c;
     let b = data.(cv);
@@ -330,6 +331,7 @@ fn ymodem_emit_data_block
       Seq.index sv 1 == blk /\
       Seq.index sv 2 == bc /\
       (forall (j:nat). j < SZ.v vi ==> Seq.index sv (3 + j) == Seq.index 'd j))
+  decreases (Prims.op_Subtraction 128 (SZ.v (!i)))
   {
     let vi = !i;
     let dv = data.(vi);
@@ -375,6 +377,7 @@ fn ymodem_recv_data_block
       Seq.length 'i == 133 /\
       Seq.length ov == 128 /\
       (forall (j:nat). j < SZ.v vi ==> Seq.index ov j == Seq.index 'i (3 + j)))
+  decreases (Prims.op_Subtraction 128 (SZ.v (!i)))
   {
     let vi = !i;
     let dv = inp.(3sz + vi);

--- a/ymodem_sample/impl/YModem.Impl.Server.Endpoint.fst
+++ b/ymodem_sample/impl/YModem.Impl.Server.Endpoint.fst
@@ -750,6 +750,7 @@ ensures exists* (d1:Seq.seq U8.t).
           SZ.v off + 128 <= Seq.length contents /\
           SZ.fits (SZ.v off + 128) /\
           (forall (k:nat). k < SZ.v vj ==> Seq.index d k == Seq.index (Ghost.reveal contents) (SZ.v off + k)))
+  decreases (128 - SZ.v (!j))
   {
     let vj = !j;
     FStar.SizeT.fits_lte (SZ.v off + SZ.v vj) (SZ.v off + 128);

--- a/ymodem_sample/impl/YModem.Impl.Server.Loop.fst
+++ b/ymodem_sample/impl/YModem.Impl.Server.Loop.fst
@@ -391,6 +391,7 @@ ensures exists* (d1:Seq.seq U8.t).
           SZ.fits (SZ.v off + 128) /\
           (forall (k:nat). k < SZ.v vj ==>
              Seq.index d k == Seq.index (Ghost.reveal contents) (SZ.v off + k)))
+  decreases (128 - SZ.v (!j))
   {
     let vj = !j;
     FStar.SizeT.fits_lte (SZ.v off + SZ.v vj) (SZ.v off + 128);
@@ -477,6 +478,7 @@ ensures exists* (chr chs pr ps:TCP.bytes) (st1:YP.ymodem_server_state)
             (rv == true ==>
               loop_coupling (Ghost.reveal contents) (Ghost.reveal nblocks)
                 (Ghost.reveal filename) (Ghost.reveal len) st cv))
+  decreases %[(if !running then 1 else 0); SZ.v (!remaining)]
   {
     with st cv. _;
     assert (pure (loop_coupling (Ghost.reveal contents) (Ghost.reveal nblocks)


### PR DESCRIPTION
## Summary

This branch upgrades the pinned EverParse toolchain to a `fstar2` build whose F\*
now enforces **termination of Pulse code**, and adds the `decreases` annotations
(plus a few helper-spec strengthenings) required to make the whole tree —
including the `calc`, `tftp`, and `ymodem` samples — verify again.

The upstream F\* change is [FStarLang/FStar#4358](https://github.com/FStarLang/FStar/pull/4358),
which splits Pulse's `stt` effect into a **terminating** `stt` and a **divergent**
`stt_div`. As a consequence, every Pulse `while` loop (and every `fn rec`) that
lives inside a plain `fn` must now carry a `decreases` clause; otherwise it is
inferred as `stt_div` and rejected inside the terminating block with:

```
* Error 228 ... Cannot compose computations in this divergent block:
  - This computation has effect: 'stt_div'
  - The continuation has effect: 'stt'
```

No behavior changes: every edit is either a `decreases` measure on an existing
loop or a (backward-compatible) strengthening of a helper's post/precondition.
The extracted C is unchanged.

## What changed

| Area | File(s) | `while` loops annotated | Helper specs strengthened |
|------|---------|:----:|:----:|
| Toolchain | `scripts/build-everparse.sh` | — | — |
| TLS (`make test`) | `src/impl/*.fst` (7 files) | 15 | 2 |
| calc sample | `calc_sample/impl/*.fst` (2 files) | 2 | 0 |
| tftp sample | `tftp_sample/impl/*.fst` (3 files) | 9 | 1 |
| ymodem sample | `ymodem_sample/impl/*.fst` (4 files) | 7 | 1 |
| **Total** | **16 F\* files** | **33** | **4** |

The recursive `fn rec` driver functions already carried `decreases (SZ.v fuel)`,
so no `fn rec` needed changes — the work is entirely in `while` loops.

### 1. Toolchain bump

`scripts/build-everparse.sh` pins the EverParse commit from
`6f1f390e…` to `ad56c6db…` (the `fstar2` branch build that enforces Pulse
termination).

### 2. The three loop-measure patterns

Every loop in the codebase falls into one of three shapes; none is genuinely
unbounded, so nothing needed `divergent fn`:

- **Counter loops** (`while (!i < bound) { …; i := i + 1 }`) — measure the
  distance to the bound:
  ```fstar
  decreases (SZ.v bound - SZ.v (!i))
  ```

- **Early-break search loops** (`while ((not !flag) && !i < count) { … }`) —
  lexicographic measure over the break flag, then the counter:
  ```fstar
  decreases %[(if !flag then 0 else 1); (SZ.v count - SZ.v (!i))]
  ```

- **Fuel loops** (`while (!running && !remaining <> 0) { … }`) — lexicographic
  measure over the run flag, then the fuel:
  ```fstar
  decreases %[(if !running then 1 else 0); SZ.v (!remaining)]
  ```

### 3. TLS core (`src/impl`, verified by `make test`)

15 loops across 7 modules:

- `TLS13.Impl.Serializer.fst`, `TLS13.Impl.Serializer.Handshake.fst`,
  `TLS13.Impl.Server.Send.fst`, `TLS13.Impl.Client.Driver.Core.fst`,
  `TLS13.Impl.Server.Driver.Network.fst` — one counter loop each.
- `TLS13.Impl.Parser.fst` — 8 loops (2 counter + 6 lexicographic early-break
  ClientHello/EncryptedExtensions/… scanners).
- `TLS13.Impl.Server.Endpoint.fst` — 1 counter loop + 1 fuel loop, **plus** the
  two helper strengthenings below.

### 4. Samples

- **calc** (`Calc.Server.Endpoint`, `Calc.Server.Socket`) — 2 fuel loops. Both
  decrement `remaining` inline, so only the `decreases` clause was needed.
- **tftp** (`TFTP.Impl.Codec`, `…Server.Loop`, `…Client.Loop`) — 9 loops
  (5 counter + 2 counter + 1 fuel + 1 fuel).
- **ymodem** (`YModem.Impl.Codec`, `…Server.Endpoint`, `…Server.Loop`,
  `…Client.Loop`) — 7 loops (3 counter + 1 counter + 1 counter + 1 fuel + 1 fuel).

## Notable technical points

### Helper-hidden fuel decrements need strengthened specs

A `decreases` clause alone is not enough when the loop delegates its
`remaining`/`running` update to a helper whose postcondition hides the decrease.
The loop measure then cannot be discharged (it surfaces as an `Error 19` pure /
measure obligation, not `Error 228`). Four helpers were strengthened:

- `TLS13.Impl.Server.Endpoint.server_decrement_endpoint_fuel` and
  `server_finish_network_result_iteration` — added
  `SZ.v rem1 < SZ.v 'rem` to their `ensures`.
- `TFTP.Impl.Client.Loop.read_status_update` and
  `YModem.Impl.Client.Loop.read_status_update` — added the precondition
  `remaining <> 0` (guaranteed by the loop guard) and the postcondition
  `running' = false \/ (running' = running /\ remaining' < remaining)`.

The calc fuel loops and the tftp/ymodem *server* fuel loops decrement inline, so
they did **not** need any helper change.

### `Pulse.Lib.BoundedIntegers` and `decreases` subtraction

In the two `*.Impl.Codec.fst` modules (which `open Pulse.Lib.BoundedIntegers`), a
naive `decreases (SZ.v n - SZ.v (!i))` fails to type-check (`Error 19`,
"ill-typed term"): because `SZ.v` returns `nat`, the overloaded `-` resolves to
the bounded-`nat` instance, whose no-underflow refinement cannot be discharged in
the `decreases` position. The fix is to force plain integer subtraction:

```fstar
decreases (Prims.op_Subtraction (SZ.v n) (SZ.v (!i)))
```

The 8 counter loops in `TFTP.Impl.Codec` and `YModem.Impl.Codec` use this form;
loops in modules that don't open `BoundedIntegers` keep the plain
`SZ.v n - SZ.v (!i)` measure.

### Dead code

`TLS13.Impl.Client.Endpoint.fst` also contains loops, but it is neither in the
`make test` verify graph nor imported anywhere, so it was left untouched.

## Testing

All four verification/extraction entry points pass in the pinned devcontainer:

- `make -j16 -k test` — all F\* modules verify; the OpenSSL echo and interop
  tests pass.
- `make -j16 -k -C calc_sample test-c` — verifies, extracts to C, and the calc
  socket test passes.
- `make -j16 -k -C tftp_sample vloop-test` — verifies, extracts the verified
  server/client loops to C, and the end-to-end SOCK_DGRAM transfer test reports
  `content MATCH`.
- `make -j16 -k -C ymodem_sample vloop-test` — verifies, extracts to C, and the
  end-to-end socketpair transfer test reports `content MATCH`.
